### PR TITLE
feat(client): add file send support and file helper (Issue #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 socp.db
 *.log
 .DS_Store
+received/

--- a/socp/cmd/client.py
+++ b/socp/cmd/client.py
@@ -19,7 +19,51 @@ def repl(ctx):
     print("SOCP client REPL. Type /list, /tell <user> <text>, /all <text>, /file <user> <path>")
     async def _run():
         async with websockets.connect(server) as ws:
+            import uuid, os
+            try:
+                from socp.core.files import chunk_file
+            except Exception:
+                chunk_file = None
             for line in sys.stdin:
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+
+                if line.startswith("/file "):
+                    if chunk_file is None:
+                        print("[error] file helper not available")
+                        await ws.send(line)
+                        continue
+                    rest = line[len("/file "):].strip()
+                    if " " not in rest:
+                        print("usage: /file <user> <path>")
+                        continue
+                    to, path = rest.split(" ", 1)
+                    path = path.strip()
+                    if not os.path.exists(path):
+                        print("[error] file not found:", path)
+                        continue
+                    file_id = str(uuid.uuid4())
+                    try:
+                        chunks, sha_hex, total = chunk_file(path)
+                    except Exception as e:
+                        print("[error] chunking failed:", e)
+                        continue 
+                    start = {"type": "FILE_START", "payload": {
+                        "file_id": file_id, "name": os.path.basename(path),
+                        "size": total, "sha256": sha_hex, "to": to
+                    }}
+                    await ws.send(json.dumps(start))
+                    for i, b64 in enumerate(chunks):
+                        chunk_frame = {"type": "FILE_CHUNK", "payload": {
+                            "file_id": file_id, "index": i, "data": b64, "to": to
+                        }}
+                        await ws.send(json.dumps(chunk_frame))
+                    end = {"type": "FILE_END", "payload": {"file_id": file_id, "to": to}}
+                    await ws.send(json.dumps(end))
+                    print(f"[sent] FILE {os.path.basename(path)} -> {to} ({total} bytes) id={file_id}")
+                    continue
+                    
                 await ws.send(line.strip())
     asyncio.run(_run())
 

--- a/socp/cmd/client.py
+++ b/socp/cmd/client.py
@@ -20,20 +20,36 @@ def repl(ctx):
     async def _run():
         async with websockets.connect(server) as ws:
             import uuid, os
+            from websockets.exceptions import ConnectionClosedError as _ConnClosed
             try:
                 from socp.core.files import chunk_file
             except Exception:
                 chunk_file = None
-            for line in sys.stdin:
-                line = line.rstrip("\n")
+
+            loop = asyncio.get_running_loop()
+            def _blocking_readline():
+                return sys.stdin.readline()
+
+            async def stdin_lines():
+                while True:
+                    line = await loop.run_in_executor(None, _blocking_readline)
+                    if not line:
+                        break
+                    yield line.rstrip("\n")
+
+            async for line in stdin_lines():
                 if not line:
                     continue
 
                 if line.startswith("/file "):
                     if chunk_file is None:
                         print("[error] file helper not available")
-                        await ws.send(line)
+                        try:
+                            await ws.send(line)
+                        except _ConnClosed:
+                            print("[error] connection closed; cannot send")
                         continue
+
                     rest = line[len("/file "):].strip()
                     if " " not in rest:
                         print("usage: /file <user> <path>")
@@ -43,28 +59,64 @@ def repl(ctx):
                     if not os.path.exists(path):
                         print("[error] file not found:", path)
                         continue
+
                     file_id = str(uuid.uuid4())
                     try:
                         chunks, sha_hex, total = chunk_file(path)
                     except Exception as e:
                         print("[error] chunking failed:", e)
-                        continue 
+                        continue
+
                     start = {"type": "FILE_START", "payload": {
                         "file_id": file_id, "name": os.path.basename(path),
                         "size": total, "sha256": sha_hex, "to": to
                     }}
-                    await ws.send(json.dumps(start))
+
+                    try:
+                        await ws.send(json.dumps(start))
+                    except _ConnClosed:
+                        print("[error] connection closed before sending FILE_START")
+                        break
+                        
+                    aborted = False
                     for i, b64 in enumerate(chunks):
                         chunk_frame = {"type": "FILE_CHUNK", "payload": {
                             "file_id": file_id, "index": i, "data": b64, "to": to
                         }}
-                        await ws.send(json.dumps(chunk_frame))
+                        try:
+                            await ws.send(json.dumps(chunk_frame))
+                        except _ConnClosed:
+                            print(f"[error] connection closed while sending chunk {i}")
+                            aborted = True
+                            break
+                        except Exception as e:
+                            print(f"[error] failed to send chunk {i}:", e)
+                            aborted = True
+                            break
+                        await asyncio.sleep(0.01)
+
+                    if aborted:
+                        print("[warn] file send aborted due to connection error")
+                        break
+
                     end = {"type": "FILE_END", "payload": {"file_id": file_id, "to": to}}
-                    await ws.send(json.dumps(end))
-                    print(f"[sent] FILE {os.path.basename(path)} -> {to} ({total} bytes) id={file_id}")
+                    try:
+                        await ws.send(json.dumps(end))
+                        print(f"[sent] FILE {os.path.basename(path)} -> {to} ({total} bytes) id={file_id}")
+                    except _ConnClosed:
+                        print("[error] connection closed while sending FILE_END")
+                        break
+
                     continue
-                    
-                await ws.send(line.strip())
+                try:
+                    await ws.send(line.strip())
+                except _ConnClosed:
+                    print("[error] connection closed; cannot send")
+                    break
+
+
+
+
     asyncio.run(_run())
 
 if __name__ == "__main__":

--- a/socp/cmd/server.py
+++ b/socp/cmd/server.py
@@ -9,7 +9,6 @@ async def main():
     ap.add_argument("--config", required=True)
     args = ap.parse_args()
 
-    # Load config (very simple YAML-like parsing for stub; replace with real yaml later)
     import yaml
     with open(args.config, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
@@ -20,9 +19,26 @@ async def main():
     await store.init(cfg.get("db_path", "socp.db"))
     await public.ensure_public_group()
 
-    # Start WS server with a simple on_message callback
+    reassembler = files.FileReassembler(out_dir="received")
+
     async def on_message(link, frame_text):
-        # TODO: parse envelope, route, verify, etc.
+        try:
+            frame = json.loads(frame_text)
+        except Exception:
+            log.warning("Received non-JSON frame (ignored): %s", frame_text[:200])
+            return
+
+        try:
+            res = files.handle_event(frame, reassembler)
+        except Exception as e:
+            log.exception("Error while handling file frame: %s", e)
+            res = None
+
+        if isinstance(res, tuple) and frame.get("type") == "FILE_END":
+            path, ok = res
+            log.info("Saved incoming file: %s verified=%s", path, ok)
+            return
+
         log.info("Received frame: %s", frame_text[:200])
 
     log.info("Starting SOCP server on %s:%d", host, port)

--- a/socp/core/files.py
+++ b/socp/core/files.py
@@ -1,5 +1,91 @@
 
+import hashlib, base64, os
+from typing import Tuple
 import logging
-log = logging.getLogger("socp.files")
+log = logging.getLogger(__name__)
 
-# TODO: implement FILE_START/FILE_CHUNK/FILE_END helpers
+DEFAULT_CHUNK_SIZE = 64 * 1024
+
+def b64e(b: bytes) -> str:
+    return base64.b64encode(b).decode("ascii")
+
+def b64d(s: str) -> bytes:
+    return base64.b64decode(s.encode("ascii"))
+
+def chunk_file(path: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> Tuple[list, str, int]:
+    """Return (list_of_base64_chunks, sha256_hex, total_bytes)."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    chunks = []
+    h = hashlib.sha256()
+    total = 0
+    with open(path, "rb") as f:
+        while True:
+            buf = f.read(chunk_size)
+            if not buf:
+                break
+            total += len(buf)
+            h.update(buf)
+            chunks.append(b64e(buf))
+    return chunks, h.hexdigest(), total
+
+class FileReassembler:
+    def __init__(self, out_dir: str = "received"):
+        self.out_dir = out_dir
+        os.makedirs(self.out_dir, exist_ok=True)
+        self.pending = {}  # file_id -> {"name":..., "sha256":..., "chunks":{idx:bytes}}
+
+    def start(self, file_id: str, name: str, size: int, sha256_hex: str):
+        self.pending[file_id] = {"name": os.path.basename(name), "sha256": sha256_hex, "chunks": {}}
+
+    def add_chunk(self, file_id: str, index: int, data_b64: str):
+        if file_id not in self.pending:
+            return
+        self.pending[file_id]["chunks"][int(index)] = b64d(data_b64)
+
+    def finish(self, file_id: str):
+        meta = self.pending.get(file_id)
+        if not meta: 
+            return "", False
+        path = os.path.join(self.out_dir, meta["name"])
+        with open(path, "wb") as out:
+            for i in sorted(meta["chunks"].keys()):
+                out.write(meta["chunks"][i])
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for bl in iter(lambda: f.read(8192), b""):
+                h.update(bl)
+        ok = (h.hexdigest() == meta["sha256"])
+        del self.pending[file_id]
+        return path, ok
+
+
+def handle_file_start(payload: dict, reassembler: FileReassembler):
+    fid = payload.get("file_id"); name = payload.get("name") or payload.get("filename")
+    size = payload.get("size", 0); sha = payload.get("sha256") or payload.get("sha")
+    if not fid or not sha: 
+        return
+    reassembler.start(fid, name, size, sha)
+
+def handle_file_chunk(payload: dict, reassembler: FileReassembler):
+    fid = payload.get("file_id"); idx = payload.get("index"); data = payload.get("data") or payload.get("chunk")
+    if fid is None or idx is None or data is None:
+        return
+    reassembler.add_chunk(fid, idx, data)
+
+def handle_file_end(payload: dict, reassembler: FileReassembler):
+    fid = payload.get("file_id")
+    if not fid: 
+        return "", False
+    return reassembler.finish(fid)
+
+FILE_HANDLERS = {
+    "FILE_START": handle_file_start,
+    "FILE_CHUNK": handle_file_chunk,
+    "FILE_END": handle_file_end,
+}
+def handle_event(frame: dict, reassembler: FileReassembler):
+    t = frame.get("type")
+    if t in FILE_HANDLERS:
+        return FILE_HANDLERS[t](frame.get("payload", {}), reassembler)
+    return None

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,23 @@
+
+from pathlib import Path
+from socp.core.files import chunk_file, FileReassembler, DEFAULT_CHUNK_SIZE
+
+def test_chunk_and_reassemble_roundtrip(tmp_path):
+    data = b"A" * (DEFAULT_CHUNK_SIZE + 123) + b"B" * 42
+    src = tmp_path / "sample.bin"
+    src.write_bytes(data)
+
+    chunks, sha_hex, total = chunk_file(str(src))
+    assert total == len(data)
+    assert len(chunks) >= 2
+
+    fr = FileReassembler(out_dir=str(tmp_path / "out"))
+    fid = "test-file-1"
+    fr.start(fid, "sample_out.bin", total, sha_hex)
+    for i, c in enumerate(chunks):
+        fr.add_chunk(fid, i, c)
+    out_path, ok = fr.finish(fid)
+    assert ok
+    assert Path(out_path).read_bytes() == data
+
+


### PR DESCRIPTION
##Summary
- Module / scope: Client file-send + helper module (`socp/core/files.py`), small client change.
- Linked issue(s): Issue #5 - implement client file-send and file helpers for peer review.

## What changed
1. Added  'socp/core/files.py` :
   -`chunk_file(path, chunk_size)`: returns base64 chunks, SHA-256, and total size.
   - FileReassembler`: accepts chunks, assembles files and verifies SHA-256 (writes to `received/`).
   - handle_file_start`, `handle_file_chunk`, `handle_file_end`, `handle_event`: light protocol helpers.
2. Updated `socp/cmd/client.py' (minimal change):
- Preserves original behaviour (sends raw lines).
- Adds parsing for `/file <user> <path>`:
- Sends `FILE_START` (payload), then `FILE_CHUNK` frames (base64 `data`), then `FILE_END`.
- Frames use `{ "type": "<TYPE>", "payload": { ... } }` shape.
3. Tests:
  - Added `tests/test_files.py` verifying chunk → reassemble roundtrip

## Tests+ Local verification

1.  Unit test:
  export PYTHONPATH="$(pwd)"
  pytest -q tests/test_files.py
  Expected: 1 passed

2. smoke test:
python -m socp.cmd.server --config configs/server.yaml
python -m socp.cmd.client --server ws://127.0.0.1:7001 repl
echo "hello" > /tmp/test-small.txt
in REPL: /file bob /tmp/test-small.txt
Expected: server logs FILE_START, FILE_CHUNK frames and FILE_END. Assembled files should appear in 'received/ ' if server wired to files.handle_event

## SOCP V1.3 compliance
- Envelope shape: I used {"type": "...", "payload": {...}}. If the server/proto expects top-level fields instead, I can swap that quickly.
- Crypto: I didn't touch crypto.py. This branch sends plaintext frames until encryption/signing is integrated.
- No routing/dedupe behaviour changed.

## Backdoor toggle 
No intentional backdoors in this branch. The vulnerable submission will be on a separate vuln/* branch as per the assignment description

## Commits included:
- feat(files): chunk_file + FileReassembler + FILE_* helpers
- feat(client): minimal /file command (sends FILE_* frames)
- test: add tests/test_files.py

## Notes for reviewer:
- @Andrew04521: please confirm whether you want file payload under payload or at top level. I can update the client to match. Also, if you want server-side auto-assembly for the smoke test, I can add a tiny patch to server.py.
- @alienblack: this branch sends cleartext chunks, let me know final envelope names when you add encryption