### PR TITLE
crypto: RSA-OAEP/PSS + canonical signing + content signatures; add pr…

### DIFF
--- a/socp/core/crypto.py
+++ b/socp/core/crypto.py
@@ -1,40 +1,85 @@
-
-import os, base64, json
+import os, base64
+from typing import Tuple
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.backends import default_backend
+from cryptography.exceptions import InvalidSignature
 
 def b64url(b: bytes) -> str:
     return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
 
+def b64url_to_bytes(s: str) -> bytes:
+    pad = "=" * ((4 - len(s) % 4) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
 def rsa_encrypt_oaep(pubkey_pem: bytes, plaintext: bytes) -> bytes:
     pub = serialization.load_pem_public_key(pubkey_pem)
-    return pub.encrypt(plaintext, padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None))
+    return pub.encrypt(
+        plaintext,
+        padding.OAEP(mgf=padding.MGF1(hashes.SHA256()),
+                     algorithm=hashes.SHA256(),
+                     label=None)
+    )
 
 def rsa_decrypt_oaep(privkey_pem: bytes, ciphertext: bytes) -> bytes:
     priv = serialization.load_pem_private_key(privkey_pem, password=None)
-    return priv.decrypt(ciphertext, padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None))
+    return priv.decrypt(
+        ciphertext,
+        padding.OAEP(mgf=padding.MGF1(hashes.SHA256()),
+                     algorithm=hashes.SHA256(),
+                     label=None)
+    )
 
 def sign_pss_sha256(privkey_pem: bytes, msg: bytes) -> bytes:
     priv = serialization.load_pem_private_key(privkey_pem, password=None)
-    return priv.sign(msg, padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())
+    return priv.sign(
+        msg,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256()
+    )
 
 def verify_pss_sha256(pubkey_pem: bytes, msg: bytes, sig: bytes) -> bool:
-    from cryptography.exceptions import InvalidSignature
     pub = serialization.load_pem_public_key(pubkey_pem)
     try:
-        pub.verify(sig, msg, padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())
+        pub.verify(
+            sig,
+            msg,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
+                        salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256()
+        )
         return True
     except InvalidSignature:
         return False
 
+def _is_rsa_pubkey_strong(pub) -> bool:
+    if not isinstance(pub, rsa.RSAPublicKey):
+        return False
+    return (pub.key_size >= 4096) and (pub.public_numbers().e == 65537)
+
+def _is_rsa_pubkey_weak_allowed(pub) -> bool:
+    if not isinstance(pub, rsa.RSAPublicKey):
+        return False
+    if os.getenv("VULN_WEAK_KEYS", "0") != "1":
+        return False
+    return pub.key_size >= 1024
+
 def accept_pubkey(pubkey_pem: bytes) -> bool:
-    # Backdoor: accept weak keys when VULN_WEAK_KEYS=1
-    allow_weak = os.getenv("VULN_WEAK_KEYS","0") == "1"
     pub = serialization.load_pem_public_key(pubkey_pem)
-    if isinstance(pub, rsa.RSAPublicKey):
-        key_size = pub.key_size
-        if allow_weak and key_size >= 1024:
-            return True
-        return key_size >= 4096
-    return False
+    return _is_rsa_pubkey_strong(pub) or _is_rsa_pubkey_weak_allowed(pub)
+
+def content_sig_bytes(ciphertext: bytes, from_id: str, to_id: str, ts_ms: int) -> bytes:
+    h = hashes.Hash(hashes.SHA256())
+    h.update(ciphertext)
+    h.update(from_id.encode("utf-8"))
+    h.update(to_id.encode("utf-8"))
+    h.update(str(ts_ms).encode("utf-8"))
+    return h.finalize()
+
+def sign_content(privkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int) -> bytes:
+    msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
+    return sign_pss_sha256(privkey_pem, msg)
+
+def verify_content(pubkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int, sig: bytes) -> bool:
+    msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
+    return verify_pss_sha256(pubkey_pem, msg, sig)

--- a/socp/core/proto.py
+++ b/socp/core/proto.py
@@ -15,3 +15,32 @@ ERROR_CODES = {"USER_NOT_FOUND","INVALID_SIG","BAD_KEY","TIMEOUT","UNKNOWN_TYPE"
 def build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
     from time import time
     return {"type": type, "from": from_, "to": to, "ts": int(time()*1000), "payload": payload, "sig": ""}
+
+# --- Helpers added for crypto transport signing & envelope building ---
+from . import crypto
+from socp.utils.canonical import canonical_bytes
+import base64, time
+from typing import Dict, Any, Optional
+
+def sign_transport(payload: dict, server_priv_pem: bytes) -> str:
+    sig = crypto.sign_pss_sha256(server_priv_pem, canonical_bytes(payload))
+    return crypto.b64url(sig)
+
+def verify_transport(payload: dict, sig_b64url: str, server_pub_pem: bytes) -> bool:
+    try:
+        sig = crypto.b64url_to_bytes(sig_b64url)
+    except Exception:
+        return False
+    return crypto.verify_pss_sha256(server_pub_pem, canonical_bytes(payload), sig)
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+def build_frame(msg_type: str, from_id: str, to_id: str, payload: Optional[Dict[str, Any]] = None, *, ts: Optional[int] = None, sig: str = "") -> Dict[str, Any]:
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a dict")
+    if ts is None:
+        ts = now_ms()
+    return {"type": msg_type, "from": from_id, "to": to_id, "ts": ts, "payload": payload, "sig": sig}

--- a/socp/utils/canonical.py
+++ b/socp/utils/canonical.py
@@ -1,5 +1,4 @@
-
 import orjson
+
 def canonical_bytes(d: dict) -> bytes:
-    # sort keys & remove whitespace (orjson does deterministic by default for same structures)
     return orjson.dumps(d, option=orjson.OPT_SORT_KEYS)

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,0 +1,6 @@
+from socp.utils.canonical import canonical_bytes
+
+def test_canonical_stability_sort_keys():
+    a = {"b": 2, "a": 1, "z": {"y": 9, "x": 8}}
+    b = {"z": {"x": 8, "y": 9}, "a": 1, "b": 2}
+    assert canonical_bytes(a) == canonical_bytes(b)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,21 +1,53 @@
-
 import os
 from socp.core import crypto
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
-def _gen_pub(size=4096):
+def _gen_key(size=4096):
     priv = rsa.generate_private_key(public_exponent=65537, key_size=size)
-    return priv.public_key().public_bytes(
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
     )
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
 
 def test_accept_pubkey_strict_and_weak():
-    pub4096 = _gen_pub(4096)
-    pub1024 = _gen_pub(1024)
-    os.environ["VULN_WEAK_KEYS"]="0"
+    _, pub4096 = _gen_key(4096)
+    _, pub1024 = _gen_key(1024)
+
+    os.environ["VULN_WEAK_KEYS"] = "0"
     assert crypto.accept_pubkey(pub4096) is True
     assert crypto.accept_pubkey(pub1024) is False
-    os.environ["VULN_WEAK_KEYS"]="1"
+
+    os.environ["VULN_WEAK_KEYS"] = "1"
     assert crypto.accept_pubkey(pub1024) is True
+
+def test_pss_sign_verify_and_tamper():
+    priv, pub = _gen_key(4096)
+    msg = b"hello world"
+    sig = crypto.sign_pss_sha256(priv, msg)
+    assert crypto.verify_pss_sha256(pub, msg, sig) is True
+    assert crypto.verify_pss_sha256(pub, msg + b"!", sig) is False
+
+def test_oaep_encrypt_decrypt_roundtrip():
+    priv, pub = _gen_key(4096)
+    pt = b"secret bytes"
+    ct = crypto.rsa_encrypt_oaep(pub, pt)
+    rt = crypto.rsa_decrypt_oaep(priv, ct)
+    assert rt == pt
+
+def test_content_signature():
+    priv, pub = _gen_key(4096)
+    ct = b"...ciphertext..."
+    from_id = "alice"
+    to_id = "bob"
+    ts = 1695800000000
+    sig = crypto.sign_content(priv, ct, from_id, to_id, ts)
+    assert crypto.verify_content(pub, ct, from_id, to_id, ts, sig) is True
+    assert crypto.verify_content(pub, ct + b"!", from_id, to_id, ts, sig) is False


### PR DESCRIPTION
…oto.build_frame() (+tests)


## Summary
- [ ] Module / scope:
- [ ] Linked issue(s):

## What changed
-

## Tests
- [ ] Added/updated tests
- [ ] `pytest -q` passes locally

## SOCP v1.3 compliance
- [ ] Envelope fields and signatures match the spec
- [ ] No server-side decryption of user content
- [ ] Routing & dedupe behavior unchanged (unless vuln branch)

## Backdoor toggle (if applicable)
- [ ] `VULN_WEAK_KEYS` or `VULN_REPLAY` touched
- [ ] Behavior documented in commit
