### PR TITLE
Crypto: RSA-OAEP/PSS + canonical signing + content signatures (+build_frame)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -36,4 +36,4 @@ Environment flags (default to ON in .env.example):
 
 Clean build: set both to 0 (or unset) and enforce strict checks.
 
-Generated on: 2025-09-27T07:33:58.199436
+Generated on: 2025-09-27T07:33:58.199436   

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ uvloop==0.19.0
 aiosqlite
 click
 pytest
+orjson
+cryptography

--- a/socp/core/.cph/.crypto.py_db46ee3e7b9d08540fb1deb890e9b955.prob
+++ b/socp/core/.cph/.crypto.py_db46ee3e7b9d08540fb1deb890e9b955.prob
@@ -1,0 +1,1 @@
+{"name":"Local: crypto","url":"/Users/alien/Downloads/socp-starter-with-branches/socp/core/crypto.py","tests":[{"id":1759496635635,"input":"","output":""}],"interactive":false,"memoryLimit":1024,"timeLimit":3000,"srcPath":"/Users/alien/Downloads/socp-starter-with-branches/socp/core/crypto.py","group":"local","local":true}

--- a/socp/core/crypto.py
+++ b/socp/core/crypto.py
@@ -83,3 +83,34 @@ def sign_content(privkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str
 def verify_content(pubkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int, sig: bytes) -> bool:
     msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
     return verify_pss_sha256(pubkey_pem, msg, sig)
+# socp/core/crypto.py
+def decrypt_and_verify_dm(sender_pub_pem, recipient_priv_pem, b64_ciphertext, from_id, to_id, ts_ms, b64_content_sig):
+    ct = b64url_to_bytes(b64_ciphertext)
+    sig = b64url_to_bytes(b64_content_sig)
+    if not verify_content(sender_pub_pem, ct, from_id, to_id, ts_ms, sig):
+        return None
+    return rsa_decrypt_oaep(recipient_priv_pem, ct)
+
+from cryptography.hazmat.primitives import serialization
+
+def generate_rsa_keypair(bits: int = 4096):
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
+
+def save_pem(path: str, pem: bytes):
+    with open(path, "wb") as f:
+        f.write(pem)
+
+def load_pem(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()

--- a/socp/core/crypto.py
+++ b/socp/core/crypto.py
@@ -1,40 +1,85 @@
-
-import os, base64, json
+import os, base64
+from typing import Tuple
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.backends import default_backend
+from cryptography.exceptions import InvalidSignature
 
 def b64url(b: bytes) -> str:
     return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
 
+def b64url_to_bytes(s: str) -> bytes:
+    pad = "=" * ((4 - len(s) % 4) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
 def rsa_encrypt_oaep(pubkey_pem: bytes, plaintext: bytes) -> bytes:
     pub = serialization.load_pem_public_key(pubkey_pem)
-    return pub.encrypt(plaintext, padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None))
+    return pub.encrypt(
+        plaintext,
+        padding.OAEP(mgf=padding.MGF1(hashes.SHA256()),
+                     algorithm=hashes.SHA256(),
+                     label=None)
+    )
 
 def rsa_decrypt_oaep(privkey_pem: bytes, ciphertext: bytes) -> bytes:
     priv = serialization.load_pem_private_key(privkey_pem, password=None)
-    return priv.decrypt(ciphertext, padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None))
+    return priv.decrypt(
+        ciphertext,
+        padding.OAEP(mgf=padding.MGF1(hashes.SHA256()),
+                     algorithm=hashes.SHA256(),
+                     label=None)
+    )
 
 def sign_pss_sha256(privkey_pem: bytes, msg: bytes) -> bytes:
     priv = serialization.load_pem_private_key(privkey_pem, password=None)
-    return priv.sign(msg, padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())
+    return priv.sign(
+        msg,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256()
+    )
 
 def verify_pss_sha256(pubkey_pem: bytes, msg: bytes, sig: bytes) -> bool:
-    from cryptography.exceptions import InvalidSignature
     pub = serialization.load_pem_public_key(pubkey_pem)
     try:
-        pub.verify(sig, msg, padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())
+        pub.verify(
+            sig,
+            msg,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
+                        salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256()
+        )
         return True
     except InvalidSignature:
         return False
 
+def _is_rsa_pubkey_strong(pub) -> bool:
+    if not isinstance(pub, rsa.RSAPublicKey):
+        return False
+    return (pub.key_size >= 4096) and (pub.public_numbers().e == 65537)
+
+def _is_rsa_pubkey_weak_allowed(pub) -> bool:
+    if not isinstance(pub, rsa.RSAPublicKey):
+        return False
+    if os.getenv("VULN_WEAK_KEYS", "0") != "1":
+        return False
+    return pub.key_size >= 1024
+
 def accept_pubkey(pubkey_pem: bytes) -> bool:
-    # Backdoor: accept weak keys when VULN_WEAK_KEYS=1
-    allow_weak = os.getenv("VULN_WEAK_KEYS","0") == "1"
     pub = serialization.load_pem_public_key(pubkey_pem)
-    if isinstance(pub, rsa.RSAPublicKey):
-        key_size = pub.key_size
-        if allow_weak and key_size >= 1024:
-            return True
-        return key_size >= 4096
-    return False
+    return _is_rsa_pubkey_strong(pub) or _is_rsa_pubkey_weak_allowed(pub)
+
+def content_sig_bytes(ciphertext: bytes, from_id: str, to_id: str, ts_ms: int) -> bytes:
+    h = hashes.Hash(hashes.SHA256())
+    h.update(ciphertext)
+    h.update(from_id.encode("utf-8"))
+    h.update(to_id.encode("utf-8"))
+    h.update(str(ts_ms).encode("utf-8"))
+    return h.finalize()
+
+def sign_content(privkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int) -> bytes:
+    msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
+    return sign_pss_sha256(privkey_pem, msg)
+
+def verify_content(pubkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int, sig: bytes) -> bool:
+    msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
+    return verify_pss_sha256(pubkey_pem, msg, sig)

--- a/socp/core/proto.py
+++ b/socp/core/proto.py
@@ -15,3 +15,32 @@ ERROR_CODES = {"USER_NOT_FOUND","INVALID_SIG","BAD_KEY","TIMEOUT","UNKNOWN_TYPE"
 def build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
     from time import time
     return {"type": type, "from": from_, "to": to, "ts": int(time()*1000), "payload": payload, "sig": ""}
+
+# --- Helpers added for crypto transport signing & envelope building ---
+from . import crypto
+from socp.utils.canonical import canonical_bytes
+import base64, time
+from typing import Dict, Any, Optional
+
+def sign_transport(payload: dict, server_priv_pem: bytes) -> str:
+    sig = crypto.sign_pss_sha256(server_priv_pem, canonical_bytes(payload))
+    return crypto.b64url(sig)
+
+def verify_transport(payload: dict, sig_b64url: str, server_pub_pem: bytes) -> bool:
+    try:
+        sig = crypto.b64url_to_bytes(sig_b64url)
+    except Exception:
+        return False
+    return crypto.verify_pss_sha256(server_pub_pem, canonical_bytes(payload), sig)
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+def build_frame(msg_type: str, from_id: str, to_id: str, payload: Optional[Dict[str, Any]] = None, *, ts: Optional[int] = None, sig: str = "") -> Dict[str, Any]:
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a dict")
+    if ts is None:
+        ts = now_ms()
+    return {"type": msg_type, "from": from_id, "to": to_id, "ts": ts, "payload": payload, "sig": sig}

--- a/socp/utils/canonical.py
+++ b/socp/utils/canonical.py
@@ -1,5 +1,4 @@
-
 import orjson
+
 def canonical_bytes(d: dict) -> bytes:
-    # sort keys & remove whitespace (orjson does deterministic by default for same structures)
     return orjson.dumps(d, option=orjson.OPT_SORT_KEYS)

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,0 +1,6 @@
+from socp.utils.canonical import canonical_bytes
+
+def test_canonical_stability_sort_keys():
+    a = {"b": 2, "a": 1, "z": {"y": 9, "x": 8}}
+    b = {"z": {"x": 8, "y": 9}, "a": 1, "b": 2}
+    assert canonical_bytes(a) == canonical_bytes(b)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,21 +1,53 @@
-
 import os
 from socp.core import crypto
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
-def _gen_pub(size=4096):
+def _gen_key(size=4096):
     priv = rsa.generate_private_key(public_exponent=65537, key_size=size)
-    return priv.public_key().public_bytes(
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
     )
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
 
 def test_accept_pubkey_strict_and_weak():
-    pub4096 = _gen_pub(4096)
-    pub1024 = _gen_pub(1024)
-    os.environ["VULN_WEAK_KEYS"]="0"
+    _, pub4096 = _gen_key(4096)
+    _, pub1024 = _gen_key(1024)
+
+    os.environ["VULN_WEAK_KEYS"] = "0"
     assert crypto.accept_pubkey(pub4096) is True
     assert crypto.accept_pubkey(pub1024) is False
-    os.environ["VULN_WEAK_KEYS"]="1"
+
+    os.environ["VULN_WEAK_KEYS"] = "1"
     assert crypto.accept_pubkey(pub1024) is True
+
+def test_pss_sign_verify_and_tamper():
+    priv, pub = _gen_key(4096)
+    msg = b"hello world"
+    sig = crypto.sign_pss_sha256(priv, msg)
+    assert crypto.verify_pss_sha256(pub, msg, sig) is True
+    assert crypto.verify_pss_sha256(pub, msg + b"!", sig) is False
+
+def test_oaep_encrypt_decrypt_roundtrip():
+    priv, pub = _gen_key(4096)
+    pt = b"secret bytes"
+    ct = crypto.rsa_encrypt_oaep(pub, pt)
+    rt = crypto.rsa_decrypt_oaep(priv, ct)
+    assert rt == pt
+
+def test_content_signature():
+    priv, pub = _gen_key(4096)
+    ct = b"...ciphertext..."
+    from_id = "alice"
+    to_id = "bob"
+    ts = 1695800000000
+    sig = crypto.sign_content(priv, ct, from_id, to_id, ts)
+    assert crypto.verify_content(pub, ct, from_id, to_id, ts, sig) is True
+    assert crypto.verify_content(pub, ct + b"!", from_id, to_id, ts, sig) is False

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -1,0 +1,39 @@
+from socp.core import crypto
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import os
+
+def _gen(bits):
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
+
+def test_decrypt_and_verify_dm():
+    s_priv, s_pub = _gen(4096)
+    r_priv, r_pub = _gen(4096)
+    msg = b"hello"
+    ct = crypto.rsa_encrypt_oaep(r_pub, msg)
+    sig = crypto.sign_content(s_priv, ct, "alice", "bob", 1695800000000)
+    pt = crypto.decrypt_and_verify_dm(s_pub, r_priv, crypto.b64url(ct), "alice","bob",1695800000000, crypto.b64url(sig))
+    assert pt == msg
+    # tamper
+    bad = crypto.decrypt_and_verify_dm(s_pub, r_priv, crypto.b64url(ct+b"!"), "alice","bob",1695800000000, crypto.b64url(sig))
+    assert bad is None
+
+def test_key_policy_boundary():
+    _, pub3072 = _gen(3072)
+    _, pub4096 = _gen(4096)
+    os.environ["VULN_WEAK_KEYS"] = "0"
+    assert crypto.accept_pubkey(pub4096) is True
+    assert crypto.accept_pubkey(pub3072) is False
+    os.environ["VULN_WEAK_KEYS"] = "1"
+    assert crypto.accept_pubkey(pub4096) is True


### PR DESCRIPTION
- Adds RSA-OAEP(SHA-256) encrypt/decrypt and RSASSA-PSS(SHA-256) sign/verify
- Adds canonical JSON bytes for transport signing (utils.canonical.canonical_bytes)
- Adds proto.build_frame() for valid envelope construction
- Enforces RSA-4096 + e=65537 by default; backdoor toggle VULN_WEAK_KEYS=1 allows RSA-1024
- Tests: crypto, canonicalization, envelope fields
