### PR TITLE
Feat/peers presence

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["tests"],
   "editor.formatOnSave": true,
-  "ruff.enable": true
+  "ruff.enable": true,
+  "python.testing.unittestEnabled": false
 }

--- a/configs/bootstrap.yaml
+++ b/configs/bootstrap.yaml
@@ -1,5 +1,5 @@
 
-introducers:
+bootstrap_servers:
   - host: "127.0.0.1"
     port: 7001
     pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_1"

--- a/configs/bootstrap.yaml
+++ b/configs/bootstrap.yaml
@@ -2,4 +2,10 @@
 introducers:
   - host: "127.0.0.1"
     port: 7001
-    pubkey: "BASE64URL_RSA4096_PUB_OF_INTRODUCER"
+    pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_1"
+  - host: "127.0.0.1"
+    port: 7002
+    pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_2"
+  - host: "127.0.0.1"
+    port: 7003
+    pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_3"

--- a/socp/core/peers.py
+++ b/socp/core/peers.py
@@ -1,9 +1,44 @@
-from typing import Any, Dict, Callable, Optional
+from __future__ import annotations
 from dataclasses import dataclass, field
-from .proto import make_envelope, now_ms, is_uuid_v4
-import logging, asyncio
-import yaml
 from pathlib import Path
+from typing import Callable, Dict, Optional
+import asyncio
+import logging
+import yaml
+
+from .proto import make_envelope, now_ms, is_uuid_v4
+
+"""
+Peers, Presence Gossip & Health
+--------------------------------
+This module maintains the server→server overlay state for SOCP v1.3:
+  • Bootstrap to an Introducer (placeholder link → remap to UUID after WELCOME)
+  • Register/refresh peer addresses on SERVER_ANNOUNCE
+  • Periodic HEARTBEATs and dead-link detection (~45s)
+  • Minimal presence seeding from SERVER_WELCOME.clients (directory hints)
+
+Wire-level obligations taken from spec (§8.1 bootstrap, §8.4 health, §7 envelope):
+  - All frames are JSON envelopes with ts in ms; transport sig covers payload only.
+  - On receiving SERVER_ANNOUNCE, register server_addrs[id] and keep a Link.
+  - Heartbeats every ~15s; treat link dead after ~45s of silence.
+
+Security/crypto:
+  - Signature verification is expected to be done in the WebSocket receive path (ws.py)
+    before calling PeerManager.on_server_frame().
+  - This module relies on the pinned RSA-4096 pubkey advertised / configured for peers.
+
+Integration points:
+  - ws.py should plug a real WebSocket send() into Link.send and route incoming frames to
+    PeerManager.on_server_frame().
+  - presence.py will consume/maintain user_locations for gossip frames; here we only seed it
+    opportunistically from SERVER_WELCOME.clients to speed up initial routing table warmup.
+
+Notes:
+  - We accept a config key "introducers" in configs/bootstrap.yaml (course repo convention).
+    If you also want to support the spec's example key "bootstrap_servers", we merge both.
+"""
+
+
 
 log = logging.getLogger("socp.peers")
 
@@ -12,51 +47,184 @@ SendFn = Callable[[dict], None]        # plug your websocket send() later
 SignFn = Callable[[bytes], str]        # transport signer (RSA-PSS in prod; HMAC stub in tests)
 NowFn  = Callable[[], int]
 
+CONFIG_PATH = Path("configs/bootstrap.yaml")
+
+
 @dataclass
 class Link:
-    server_id: str                   # UUID v4 when known; until then we can use "host:port"
+    """A transport handle for a remote Server in the overlay.
+
+    server_id: UUID v4 once known (placeholder "host:port" allowed pre-WELCOME)
+    host/port: advertised WS endpoint
+    pubkey_b64: pinned transport key from bootstrap / welcome
+    send: callable that ships a JSON envelope over the wire
+    last_seen_ms: for liveness/timeout tracking
+    """
+    server_id: str
     host: str
     port: int
-    pubkey_b64: str                  # pinned transport key from bootstrap / welcome
+    pubkey_b64: str
     send: SendFn = lambda _msg: None
     last_seen_ms: int = field(default_factory=now_ms)
     is_alive: bool = True
     reconnecting: bool = False
-    
+
+
 class PeerManager:
-    """
+    """Manages server links, addresses, and health.
+
     - server_links: Dict[server_id -> Link]
-    - introducers:   raw introducer entries from YAML
-    - heartbeat / timeout (send ~15s, dead after ~45s)
+    - server_addrs: Dict[server_id -> (host, port)]
+    - user_locations: Dict[user_id -> "local" | server_id]
+
+    Callers should:
+      • create PeerManager
+      • populate with introducer placeholders (bootstrap())
+      • wire ws.py to call on_server_frame() per incoming server frame (after sig check)
+      • use make_* helpers to craft envelopes to send
     """
-    def __init__(self, my_server_id: str, sign_transport: SignFn,
-                 now: NowFn = now_ms, on_dead: Optional[Callable[[str], None]] = None):
+
+    def __init__(
+        self,
+        my_server_id: str,
+        sign_transport: SignFn,
+        now: NowFn = now_ms,
+        on_dead: Optional[Callable[[str], None]] = None,
+    ):
         self.my_server_id = my_server_id
         self.sign_transport = sign_transport
         self.now = now
         self.on_dead = on_dead
-        self.server_links: Dict[str, Link] = {}
-        self.introducers: list[dict] = []
 
-    # ----- YAML loader (optional; if you already pass a list, you can skip this) -----
-    def load_bootstrap_yaml(self, path: str | Path) -> list[dict]:
-        data = yaml.safe_load(Path(path).read_text()) or {}
-        self.introducers = data.get("bootstrap_servers", [])
-        return self.introducers
+        self.server_links: Dict[str, Link] = {}
+        self.server_addrs: Dict[str, tuple[str, int]] = {}
+        self.user_locations: Dict[str, str] = {}
+
+        # Tracks any pre-WELCOME placeholder link keys (e.g., "1.2.3.4:9001").
+        self._placeholders: set[str] = set()
+
+    # ----- config -----
+    def load_config(self, override_path: Optional[str] = None) -> list[dict]:
+        """Load introducers from YAML.
+        """
+        path = Path(override_path) if override_path else CONFIG_PATH
+        data = yaml.safe_load(path.read_text()) or {}
+        intro_b = data.get("bootstrap_servers", []) or []
+        # Normalize entries to {host, port, pubkey}
+        def norm(ent: dict) -> dict:
+            return {
+                "host": ent.get("host"),
+                "port": int(ent.get("port")),
+                "pubkey": ent.get("pubkey"),
+            }
+        merged = [norm(e) for e in intro_b if e]
+        return merged
 
     # ----- spec message constructors -----
     def make_server_hello_join(self, intro_host: str, intro_port: int, my_pubkey_b64: str) -> dict:
-        # to can be "host:port" during join
+        """SERVER_HELLO_JOIN — join request to an Introducer.
+
+        Envelope 'to' may be the literal "host:port" during join (§8.1).
+        """
         payload = {"host": intro_host, "port": intro_port, "pubkey": my_pubkey_b64}
-        return make_envelope("SERVER_HELLO_JOIN", self.my_server_id, f"{intro_host}:{intro_port}",
-                             payload, self.sign_transport)
+        return make_envelope(
+            "SERVER_HELLO_JOIN",
+            self.my_server_id,
+            f"{intro_host}:{intro_port}",
+            payload,
+            self.sign_transport,
+        )
+
+    def handle_server_welcome(self, env: dict) -> None:
+        """Process SERVER_WELCOME from Introducer.
+
+        - Update my_server_id if the introducer re-assigned it (§8.1).
+        - Remap placeholder link (host:port) → real introducer UUID from env["from"].
+        - Seed presence hints from payload.clients (optional optimization).
+        """
+        payload = env.get("payload", {})
+        assigned = payload.get("assigned_id")
+        if assigned and assigned != self.my_server_id:
+            log.info("Introducer assigned server_id=%s (was %s)", assigned, self.my_server_id)
+            self.my_server_id = assigned
+
+        introducer_sid = env.get("from")
+        if introducer_sid and is_uuid_v4(introducer_sid):
+            # Remap first placeholder, if any, to the introducer's UUID.
+            if self._placeholders:
+                placeholder_key = next(iter(self._placeholders))
+                link = self.server_links.pop(placeholder_key, None)
+                if link:
+                    link.server_id = introducer_sid
+                    self.server_links[introducer_sid] = link
+                    self.server_addrs[introducer_sid] = (link.host, link.port)
+                self._placeholders.discard(placeholder_key)
+
+        # Seed presence (directory hints) — server_id is introducer's.
+        for c in payload.get("clients", []) or []:
+            try:
+                uid = c["user_id"]
+                self.user_locations[uid] = introducer_sid
+            except Exception:
+                continue
 
     def make_server_announce(self, my_host: str, my_port: int, my_pubkey_b64: str) -> dict:
+        """SERVER_ANNOUNCE — broadcast our address + pubkey to all servers (§8.1)."""
         payload = {"host": my_host, "port": my_port, "pubkey": my_pubkey_b64}
         return make_envelope("SERVER_ANNOUNCE", self.my_server_id, "*", payload, self.sign_transport)
 
+    def handle_server_announce(self, env: dict) -> None:
+        """Register/update the announcing server's address and liveness (§8.1)."""
+        from_sid = env.get("from")
+        if not (from_sid and is_uuid_v4(from_sid)):
+            # Ignore malformed/mis-sent announces; ws.py should already filter via sig check.
+            return
+        p = env.get("payload", {})
+        try:
+            host, port, pubkey = p["host"], int(p["port"]), p["pubkey"]
+        except Exception:
+            return
+
+        # Store/refresh address and Link
+        self.server_addrs[from_sid] = (host, port)
+        link = self.server_links.get(from_sid)
+        if not link:
+            link = Link(
+                server_id=from_sid,
+                host=host,
+                port=port,
+                pubkey_b64=pubkey,
+                send=_stub_send_factory(host, port),  # !!!! ws.py will replace with real ws.send
+            )
+            self.server_links[from_sid] = link
+        else:
+            # Keep timestamps/flags; update endpoint and pinned key (key rotation permitted by policy)
+            link.host, link.port, link.pubkey_b64 = host, port, pubkey
+
+        self.note_frame(from_sid)
+
     def make_heartbeat(self, to_server_id: str) -> dict:
         return make_envelope("HEARTBEAT", self.my_server_id, to_server_id, {}, self.sign_transport)
+
+    # ----- ingress from ws.py -----
+    def on_server_frame(self, env: dict) -> None:
+        """Entry point for each validated server→server frame.
+
+        Assumes JSON parsed and transport signature verified by caller.
+        """
+        t = env.get("type")
+        frm = env.get("from")
+        if frm:
+            self.note_frame(frm)
+
+        if t == "SERVER_WELCOME" and env.get("to") == self.my_server_id:
+            self.handle_server_welcome(env)
+        elif t == "SERVER_ANNOUNCE":
+            self.handle_server_announce(env)
+        # elif t == "HEARTBEAT":
+        #     pass  # liveness already updated by note_frame()
+        else:
+            pass
 
     # ----- bookkeeping on any received server frame -----
     def note_frame(self, from_server_id: str) -> None:
@@ -67,22 +235,35 @@ class PeerManager:
 
     # ----- broadcast helper -----
     def broadcast_envelope(self, env: dict) -> None:
+        """Send an already-constructed envelope to all currently alive peers.
+        Caller ensures 'to' matches the desired audience (e.g., "*").
+        """
         for link in list(self.server_links.values()):
+            if not link.is_alive:
+                continue
             try:
                 link.send(env)
             except Exception:
                 link.is_alive = False
+                link.reconnecting = True
 
     # ----- health / timeouts -----
     def tick_health(self, timeout_s: float = 45.0) -> None:
         now = self.now()
+        deadline = int(timeout_s * 1000)
         for sid, link in list(self.server_links.items()):
-            if link.is_alive and (now - link.last_seen_ms) > int(timeout_s * 1000):
+            if link.is_alive and (now - link.last_seen_ms) > deadline:
                 link.is_alive = False
                 link.reconnecting = True
+                log.warning("Marking server %s dead (no frames for %ss)", sid, int(timeout_s))
                 if self.on_dead:
-                    self.on_dead(sid)
-                    
+                    try:
+                        self.on_dead(sid)
+                    except Exception:
+                        log.exception("on_dead callback error for %s", sid)
+
+
+# ----- bootstrap API -----
 async def bootstrap(
     *,
     my_server_id: str,
@@ -90,79 +271,114 @@ async def bootstrap(
     my_port: int,
     my_pubkey_b64: str,
     sign_transport: SignFn,
-    bootstrap_list: list[dict] | None = None,
-    bootstrap_yaml_path: str | None = None,
+    bootstrap_list: Optional[list[dict]] = None,
+    bootstrap_yaml_path: Optional[str] = None,
     on_dead: Optional[Callable[[str], None]] = None,
 ) -> PeerManager:
-    """
-    Spec-compliant bootstrap:
-      - validate introducers (host/port/pubkey)
-      - create PeerManager + Link placeholders for each introducer
-      - craft SERVER_HELLO_JOIN for each introducer (you'll actually send on WS later)
-      - craft SERVER_ANNOUNCE ready to fan out after WELCOME
-      - start a heartbeat task (timer) you can hook to your scheduler
+    """Spec-compliant bootstrap (no real sockets yet; send() is a stub here).
 
-    Returns a configured PeerManager; no real sockets yet (send() is a stub).
+    Steps (matching §8.1):
+      1) Load introducers (config list overrides YAML; YAML overrides default path).
+      2) Create PeerManager and placeholder Link(s) keyed by "host:port".
+      3) Send SERVER_HELLO_JOIN to first reachable introducer (real code: over WebSocket).
+      4) Prepare SERVER_ANNOUNCE to broadcast *after* receiving SERVER_WELCOME.
+      5) Start heartbeat loop (application-level) — caller still needs ws integration.
     """
     pm = PeerManager(my_server_id=my_server_id, sign_transport=sign_transport, on_dead=on_dead)
 
-    # 1) get introducers
-    if bootstrap_list is None:
-        if not bootstrap_yaml_path:
-            raise ValueError("Provide bootstrap_list or bootstrap_yaml_path")
-        bootstrap_list = pm.load_bootstrap_yaml(bootstrap_yaml_path)
+    # 1) Resolve introducers
+    introducers: list[dict]
+    if bootstrap_list:
+        introducers = bootstrap_list
     else:
-        pm.introducers = bootstrap_list
+        introducers = pm.load_config(bootstrap_yaml_path)
 
-    # 2) validate introducers per spec and create Link placeholders
-    for idx, ent in enumerate(bootstrap_list):
+    if not introducers:
+        raise ValueError("No introducers found")
+
+    # 2) Attempt introducers sequentially (basic failover)
+    for ent in introducers:
         try:
-            host = ent["host"]; port = int(ent["port"]); pubkey = ent["pubkey"]
+            host, port, pubkey = ent["host"], int(ent["port"]), ent["pubkey"]
+            sid_placeholder = f"{host}:{port}"
+
+            link = Link(
+                server_id=sid_placeholder,
+                host=host,
+                port=port,
+                pubkey_b64=pubkey,
+                send=_stub_send_factory(host, port),  # replace later with ws.send
+            )
+            pm.server_links[sid_placeholder] = link
+            pm.server_addrs[sid_placeholder] = (host, port)  # seed for reconnect stub
+            pm._placeholders.add(sid_placeholder)
+
+            hello = pm.make_server_hello_join(host, port, my_pubkey_b64)
+            log.info("→ Trying introducer %s:%s (SERVER_HELLO_JOIN)", host, port)
+            link.send(hello)
+
+            # Real implementation would now await SERVER_WELCOME on ws receive path.
+            # We stop after the first attempted dial; higher-level code can continue the flow.
+            break
+
         except Exception as e:
-            raise ValueError(f"Invalid introducer entry at index {idx}: {ent!r}") from e
+            log.warning("Introducer %s:%s failed (%s), trying next...", ent.get("host"), ent.get("port"), e)
+    else:
+        raise RuntimeError("All introducers unreachable")
 
-        sid_placeholder = f"{host}:{port}"  # allowed pre-WELCOME
-        pm.server_links[sid_placeholder] = Link(
-            server_id=sid_placeholder,
-            host=host,
-            port=port,
-            pubkey_b64=pubkey,
-            send=_stub_send_factory(host, port),  # replace with your ws send later
-        )
-
-    # 3) craft join messages (you'll actually send them on your WS connection)
-    for link in pm.server_links.values():
-        if ":" in link.server_id:  # introducer placeholders
-            hello = pm.make_server_hello_join(link.host, link.port, my_pubkey_b64)
-            log.info("→ SERVER_HELLO_JOIN %s", hello)
-            link.send(hello)  # currently logs; wire to WS later
-
-    # 4) prepare your own announce (broadcast) for when you’re connected
+    # 3) Prepare our own announce (broadcast after WELCOME)
     announce = pm.make_server_announce(my_host, my_port, my_pubkey_b64)
     log.info("Prepared SERVER_ANNOUNCE (broadcast after WELCOME): %s", announce)
 
-    # 5) (optional) start a heartbeat loop (timer only; you still need WS send)
+    # 4) Start heartbeat loop (timer only; ws send still a stub here)
     asyncio.create_task(_heartbeat_loop(pm))
 
     return pm
 
-# ----- tiny helpers -----
+
+# ----- helpers -----
 def _stub_send_factory(host: str, port: int) -> SendFn:
     def _send(msg: dict) -> None:
-        # replace with: ws.send(json.dumps(msg))
+        # Replace with real WebSocket send: ws.send(json.dumps(msg))
         log.debug("[stub-send %s:%s] %s", host, port, msg)
     return _send
 
+
 async def _heartbeat_loop(pm: PeerManager, interval_s: float = 15.0) -> None:
+    """Periodic liveness maintenance.
+
+    - Ticks health (dead after ~45s without frames) (§8.4)
+    - Sends HEARTBEATs to known UUID peers (skip placeholders)
+    - Very naive reconnect stub that rebinds send() from server_addrs if flagged
+    """
     while True:
         try:
-            pm.tick_health(timeout_s=45.0)  # spec: dead after ~45s
-            # if you already know peer UUIDs, you can also build and send HEARTBEATs here
-            # for sid, link in pm.server_links.items():
-            #     if link.is_alive and is_uuid_v4(sid):
-            #         hb = pm.make_heartbeat(sid)
-            #         link.send(hb)
+            pm.tick_health(timeout_s=45.0)
+
+            # Application-level heartbeats to known UUID peers
+            for sid, link in list(pm.server_links.items()):
+                if link.is_alive and is_uuid_v4(sid):
+                    hb = pm.make_heartbeat(sid)
+                    try:
+                        link.send(hb)
+                    except Exception:
+                        link.is_alive = False
+                        link.reconnecting = True
+
+            # RECONNECT STUB: a policy sketch; real WS dialing should live in connection mgr
+            for sid, link in list(pm.server_links.items()):
+                if link.reconnecting:
+                    addr = pm.server_addrs.get(sid)
+                    if addr:
+                        host, port = addr
+                        link.send = _stub_send_factory(host, port)
+                        # Mark as retried. A real socket layer would mark alive only on successful handshake.
+                        link.reconnecting = False
+
         except Exception:
             log.exception("heartbeat loop error")
+
         await asyncio.sleep(interval_s)
-        
+
+
+#In ws.py, ts should be added in make_envelope.

--- a/socp/core/peers.py
+++ b/socp/core/peers.py
@@ -1,8 +1,168 @@
-
+from typing import Any, Dict, Callable, Optional
+from dataclasses import dataclass, field
+from .proto import make_envelope, now_ms, is_uuid_v4
 import logging, asyncio
+import yaml
+from pathlib import Path
+
 log = logging.getLogger("socp.peers")
 
-async def bootstrap(bootstrap_list):
-    # TODO: connect to introducers, validate, then link peers
-    log.info("Bootstrap with introducers: %s", bootstrap_list)
-    return {}
+# ---------- types ----------
+SendFn = Callable[[dict], None]        # plug your websocket send() later
+SignFn = Callable[[bytes], str]        # transport signer (RSA-PSS in prod; HMAC stub in tests)
+NowFn  = Callable[[], int]
+
+@dataclass
+class Link:
+    server_id: str                   # UUID v4 when known; until then we can use "host:port"
+    host: str
+    port: int
+    pubkey_b64: str                  # pinned transport key from bootstrap / welcome
+    send: SendFn = lambda _msg: None
+    last_seen_ms: int = field(default_factory=now_ms)
+    is_alive: bool = True
+    reconnecting: bool = False
+    
+class PeerManager:
+    """
+    - server_links: Dict[server_id -> Link]
+    - introducers:   raw introducer entries from YAML
+    - heartbeat / timeout (send ~15s, dead after ~45s)
+    """
+    def __init__(self, my_server_id: str, sign_transport: SignFn,
+                 now: NowFn = now_ms, on_dead: Optional[Callable[[str], None]] = None):
+        self.my_server_id = my_server_id
+        self.sign_transport = sign_transport
+        self.now = now
+        self.on_dead = on_dead
+        self.server_links: Dict[str, Link] = {}
+        self.introducers: list[dict] = []
+
+    # ----- YAML loader (optional; if you already pass a list, you can skip this) -----
+    def load_bootstrap_yaml(self, path: str | Path) -> list[dict]:
+        data = yaml.safe_load(Path(path).read_text()) or {}
+        self.introducers = data.get("bootstrap_servers", [])
+        return self.introducers
+
+    # ----- spec message constructors -----
+    def make_server_hello_join(self, intro_host: str, intro_port: int, my_pubkey_b64: str) -> dict:
+        # to can be "host:port" during join
+        payload = {"host": intro_host, "port": intro_port, "pubkey": my_pubkey_b64}
+        return make_envelope("SERVER_HELLO_JOIN", self.my_server_id, f"{intro_host}:{intro_port}",
+                             payload, self.sign_transport)
+
+    def make_server_announce(self, my_host: str, my_port: int, my_pubkey_b64: str) -> dict:
+        payload = {"host": my_host, "port": my_port, "pubkey": my_pubkey_b64}
+        return make_envelope("SERVER_ANNOUNCE", self.my_server_id, "*", payload, self.sign_transport)
+
+    def make_heartbeat(self, to_server_id: str) -> dict:
+        return make_envelope("HEARTBEAT", self.my_server_id, to_server_id, {}, self.sign_transport)
+
+    # ----- bookkeeping on any received server frame -----
+    def note_frame(self, from_server_id: str) -> None:
+        link = self.server_links.get(from_server_id)
+        if link:
+            link.last_seen_ms = self.now()
+            link.is_alive = True
+
+    # ----- broadcast helper -----
+    def broadcast_envelope(self, env: dict) -> None:
+        for link in list(self.server_links.values()):
+            try:
+                link.send(env)
+            except Exception:
+                link.is_alive = False
+
+    # ----- health / timeouts -----
+    def tick_health(self, timeout_s: float = 45.0) -> None:
+        now = self.now()
+        for sid, link in list(self.server_links.items()):
+            if link.is_alive and (now - link.last_seen_ms) > int(timeout_s * 1000):
+                link.is_alive = False
+                link.reconnecting = True
+                if self.on_dead:
+                    self.on_dead(sid)
+                    
+async def bootstrap(
+    *,
+    my_server_id: str,
+    my_host: str,
+    my_port: int,
+    my_pubkey_b64: str,
+    sign_transport: SignFn,
+    bootstrap_list: list[dict] | None = None,
+    bootstrap_yaml_path: str | None = None,
+    on_dead: Optional[Callable[[str], None]] = None,
+) -> PeerManager:
+    """
+    Spec-compliant bootstrap:
+      - validate introducers (host/port/pubkey)
+      - create PeerManager + Link placeholders for each introducer
+      - craft SERVER_HELLO_JOIN for each introducer (you'll actually send on WS later)
+      - craft SERVER_ANNOUNCE ready to fan out after WELCOME
+      - start a heartbeat task (timer) you can hook to your scheduler
+
+    Returns a configured PeerManager; no real sockets yet (send() is a stub).
+    """
+    pm = PeerManager(my_server_id=my_server_id, sign_transport=sign_transport, on_dead=on_dead)
+
+    # 1) get introducers
+    if bootstrap_list is None:
+        if not bootstrap_yaml_path:
+            raise ValueError("Provide bootstrap_list or bootstrap_yaml_path")
+        bootstrap_list = pm.load_bootstrap_yaml(bootstrap_yaml_path)
+    else:
+        pm.introducers = bootstrap_list
+
+    # 2) validate introducers per spec and create Link placeholders
+    for idx, ent in enumerate(bootstrap_list):
+        try:
+            host = ent["host"]; port = int(ent["port"]); pubkey = ent["pubkey"]
+        except Exception as e:
+            raise ValueError(f"Invalid introducer entry at index {idx}: {ent!r}") from e
+
+        sid_placeholder = f"{host}:{port}"  # allowed pre-WELCOME
+        pm.server_links[sid_placeholder] = Link(
+            server_id=sid_placeholder,
+            host=host,
+            port=port,
+            pubkey_b64=pubkey,
+            send=_stub_send_factory(host, port),  # replace with your ws send later
+        )
+
+    # 3) craft join messages (you'll actually send them on your WS connection)
+    for link in pm.server_links.values():
+        if ":" in link.server_id:  # introducer placeholders
+            hello = pm.make_server_hello_join(link.host, link.port, my_pubkey_b64)
+            log.info("→ SERVER_HELLO_JOIN %s", hello)
+            link.send(hello)  # currently logs; wire to WS later
+
+    # 4) prepare your own announce (broadcast) for when you’re connected
+    announce = pm.make_server_announce(my_host, my_port, my_pubkey_b64)
+    log.info("Prepared SERVER_ANNOUNCE (broadcast after WELCOME): %s", announce)
+
+    # 5) (optional) start a heartbeat loop (timer only; you still need WS send)
+    asyncio.create_task(_heartbeat_loop(pm))
+
+    return pm
+
+# ----- tiny helpers -----
+def _stub_send_factory(host: str, port: int) -> SendFn:
+    def _send(msg: dict) -> None:
+        # replace with: ws.send(json.dumps(msg))
+        log.debug("[stub-send %s:%s] %s", host, port, msg)
+    return _send
+
+async def _heartbeat_loop(pm: PeerManager, interval_s: float = 15.0) -> None:
+    while True:
+        try:
+            pm.tick_health(timeout_s=45.0)  # spec: dead after ~45s
+            # if you already know peer UUIDs, you can also build and send HEARTBEATs here
+            # for sid, link in pm.server_links.items():
+            #     if link.is_alive and is_uuid_v4(sid):
+            #         hb = pm.make_heartbeat(sid)
+            #         link.send(hb)
+        except Exception:
+            log.exception("heartbeat loop error")
+        await asyncio.sleep(interval_s)
+        

--- a/socp/core/peers.py
+++ b/socp/core/peers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Optional
+from . import presence as presence_mod
 import asyncio
 import logging
 import yaml
@@ -95,6 +96,7 @@ class PeerManager:
         self.sign_transport = sign_transport
         self.now = now
         self.on_dead = on_dead
+        self._pending_announce = None
 
         self.server_links: Dict[str, Link] = {}
         self.server_addrs: Dict[str, tuple[str, int]] = {}
@@ -135,6 +137,10 @@ class PeerManager:
             self.sign_transport,
         )
 
+    def list_online_users(self) -> list[str]:
+        """Return a sorted list of known online users for `/list`."""
+        return sorted(self.user_locations.keys())
+    
     def handle_server_welcome(self, env: dict) -> None:
         """Process SERVER_WELCOME from Introducer.
 
@@ -167,6 +173,11 @@ class PeerManager:
                 self.user_locations[uid] = introducer_sid
             except Exception:
                 continue
+            
+        if self._pending_announce:
+            self.broadcast_envelope(self._pending_announce)
+            self._pending_announce = None
+
 
     def make_server_announce(self, my_host: str, my_port: int, my_pubkey_b64: str) -> dict:
         """SERVER_ANNOUNCE — broadcast our address + pubkey to all servers (§8.1)."""
@@ -206,6 +217,33 @@ class PeerManager:
     def make_heartbeat(self, to_server_id: str) -> dict:
         return make_envelope("HEARTBEAT", self.my_server_id, to_server_id, {}, self.sign_transport)
 
+    def _verify_from_server(self, env: dict) -> bool:
+    # Real verify is done in ws.py before calling on_server_frame()
+        return True
+
+    def _fanout_unchanged(self, env: dict) -> None:
+        self.broadcast_envelope(env)
+
+    def _handle_presence_frames(self, env: dict) -> bool:
+        t = env.get("type")
+        if t == "USER_ADVERTISE":
+            return presence_mod.handle_user_advertise(
+                env,
+                my_server_id=self.my_server_id,
+                user_locations=self.user_locations,
+                verify_from_server=self._verify_from_server,
+                fanout=self._fanout_unchanged,
+            )
+        if t == "USER_REMOVE":
+            return presence_mod.handle_user_remove(
+                env,
+                my_server_id=self.my_server_id,
+                user_locations=self.user_locations,
+                verify_from_server=self._verify_from_server,
+                fanout=self._fanout_unchanged,
+            )
+        return False
+
     # ----- ingress from ws.py -----
     def on_server_frame(self, env: dict) -> None:
         """Entry point for each validated server→server frame.
@@ -221,8 +259,8 @@ class PeerManager:
             self.handle_server_welcome(env)
         elif t == "SERVER_ANNOUNCE":
             self.handle_server_announce(env)
-        # elif t == "HEARTBEAT":
-        #     pass  # liveness already updated by note_frame()
+        elif t in ("USER_ADVERTISE", "USER_REMOVE"):
+            self._handle_presence_frames(env)
         else:
             pass
 
@@ -284,7 +322,11 @@ async def bootstrap(
       4) Prepare SERVER_ANNOUNCE to broadcast *after* receiving SERVER_WELCOME.
       5) Start heartbeat loop (application-level) — caller still needs ws integration.
     """
-    pm = PeerManager(my_server_id=my_server_id, sign_transport=sign_transport, on_dead=on_dead)
+    def on_dead_purge(server_id: str):
+    # Called automatically when a peer is marked dead in tick_health()
+        presence_mod.purge_by_hosting_server(server_id, pm.user_locations)
+    
+    pm = PeerManager(my_server_id=my_server_id, sign_transport=sign_transport, on_dead=on_dead_purge)
 
     # 1) Resolve introducers
     introducers: list[dict]
@@ -328,6 +370,7 @@ async def bootstrap(
 
     # 3) Prepare our own announce (broadcast after WELCOME)
     announce = pm.make_server_announce(my_host, my_port, my_pubkey_b64)
+    pm._pending_announce = announce
     log.info("Prepared SERVER_ANNOUNCE (broadcast after WELCOME): %s", announce)
 
     # 4) Start heartbeat loop (timer only; ws send still a stub here)

--- a/socp/core/presence.py
+++ b/socp/core/presence.py
@@ -1,11 +1,117 @@
 
 import logging
+from typing import Callable, Dict
+from .proto import build_frame, sign_frame_in_place
+
 log = logging.getLogger("socp.presence")
 
-async def on_user_local_join(user_id: str, meta: dict):
-    # TODO: broadcast USER_ADVERTISE
-    log.info("Advertise user join: %s", user_id)
 
-async def on_user_local_leave(user_id: str):
-    # TODO: broadcast USER_REMOVE
+user_locations: Dict[str, str] = {}
+
+# type aliases
+SignFn = Callable[[bytes], str]          # transport signer (RSA-PSS in prod; HMAC stub in tests)
+BroadcastFn = Callable[[dict], None]     # e.g., PeerManager.broadcast_envelope
+VerifyFn = Callable[[dict], bool]        # given an envelope, verify sig with sender's pinned pubkey
+
+async def on_user_local_join(
+    user_id: str, 
+    meta: dict,
+    *,
+    my_server_id: str,
+    sign_transport: SignFn,
+    broadcast: BroadcastFn,)->dict:
+    
+    """
+    Called when a local user connects.
+    Builds and broadcasts a USER_ADVERTISE envelope.
+    """
+    payload = {"user_id": user_id, "server_id": my_server_id, "meta": meta or {}}
+    
+    frame = build_frame("USER_ADVERTISE", my_server_id, "*", payload)
+    env = sign_frame_in_place(frame, sign_transport)
+
+    # optimistic update for our own table
+    user_locations[user_id] = "local"
+
+    broadcast(env)
+    log.info("Advertise user join: %s", user_id)
+    return env
+
+async def on_user_local_leave(user_id: str, *,
+    my_server_id: str,
+    sign_transport: SignFn,
+    broadcast: BroadcastFn)->dict:
+    
+    """
+    Called when a local user disconnects.
+    Builds and broadcasts a USER_REMOVE envelope.
+    """
+
+    payload = {"user_id": user_id, "server_id": my_server_id}
+    
+    frame = build_frame("USER_REMOVE", my_server_id, "*", payload)
+    env = sign_frame_in_place(frame, sign_transport)    
+
+    broadcast(env)
     log.info("Advertise user leave: %s", user_id)
+    return env
+
+# -------------------------------
+# gossip handlers
+# -------------------------------
+
+def handle_user_advertise(
+    env: dict,
+    *,
+    my_server_id: str,
+    verify_from_server: VerifyFn,
+    fanout: BroadcastFn,
+) -> bool:
+    """
+    Process a USER_ADVERTISE from another server.
+    Updates user_locations and fans out unchanged envelope.
+    """
+    if env.get("type") != "USER_ADVERTISE":
+        return False
+    if not verify_from_server(env):
+        log.warning("Rejected USER_ADVERTISE (bad sig) from %s", env.get("from"))
+        return False
+
+    payload = env["payload"]
+    uid, hosting_sid = payload["user_id"], payload["server_id"]
+    user_locations[uid] = "local" if hosting_sid == my_server_id else hosting_sid
+    fanout(env)
+    log.info("Processed USER_ADVERTISE for %s hosted on %s", uid, hosting_sid)
+    return True
+
+
+def handle_user_remove(
+    env: dict,
+    *,
+    my_server_id: str,
+    verify_from_server: VerifyFn,
+    fanout: BroadcastFn,
+) -> bool:
+    """
+    Process a USER_REMOVE with guarded removal.
+    Only accept if the hosting server matches current mapping.
+    """
+    if env.get("type") != "USER_REMOVE":
+        return False
+    if not verify_from_server(env):
+        log.warning("Rejected USER_REMOVE (bad sig) from %s", env.get("from"))
+        return False
+
+    payload = env["payload"]
+    uid, hosting_sid = payload["user_id"], payload["server_id"]
+
+    current = user_locations.get(uid)
+    if current in ("local", hosting_sid):
+        user_locations.pop(uid, None)
+        fanout(env)
+        log.info("Processed USER_REMOVE for %s hosted on %s", uid, hosting_sid)
+        return True
+
+    log.debug("Ignored USER_REMOVE for %s (not hosted on %s)", uid, hosting_sid)
+    return False
+

--- a/socp/core/presence.py
+++ b/socp/core/presence.py
@@ -1,87 +1,152 @@
-
+from __future__ import annotations
+from typing import Callable, Dict, Iterable
 import logging
-from typing import Callable, Dict
-from .proto import build_frame, sign_frame_in_place
+
+from .proto import build_frame, sign_frame_in_place, is_uuid_v4
+
+
+"""
+Presence Gossip (SOCP v1.3)
+---------------------------
+This module implements the server-side presence gossip required by the spec:
+  • Broadcast local joins/leaves as USER_ADVERTISE / USER_REMOVE
+  • Verify incoming server-origin frames before mutating routing tables
+  • Guarded removal: only accept USER_REMOVE if our current mapping still points to that server
+  • Fan-out valid gossip unchanged (mesh gossip; duplicate suppression should be handled elsewhere)
+
+Minimal integration contract
+============================
+- proto.build_frame(type, from_, to, payload)  → dict (injects ts in ms; no sig)
+- proto.sign_frame_in_place(env, sign_fn)      → dict (returns the same env with transport sig)
+- proto.is_uuid_v4(value)                      → bool (format check for server_id/user_id)
+
+Callers provide:
+- sign_transport:   SignFn, used for our locally-originating frames
+- broadcast:        BroadcastFn, to fan-out envelopes to peer servers (e.g., PeerManager.broadcast)
+- verify_from_srv:  VerifyFn, validates transport signature of an incoming server frame
+- user_locations:   Dict[user_id -> "local" | server_id], shared with peers/routers
+
+Notes
+-----
+- This module deliberately does not perform duplicate suppression; peers layer should drop
+  dup gossip by (ts, from, to, hash(payload)).
+- The verify function should pin the public key of env["from"] and re-compute the transport
+  signature over the canonical payload (per spec §12). We only enforce shape here.
+"""
+
 
 log = logging.getLogger("socp.presence")
 
+# ---- types ----
+SignFn      = Callable[[bytes], str]          # transport signer (RSASSA-PSS in prod)
+BroadcastFn = Callable[[dict], None]          # e.g., PeerManager.broadcast_envelope
+VerifyFn    = Callable[[dict], bool]          # verify transport sig using sender's pinned pubkey
 
-user_locations: Dict[str, str] = {}
 
-# type aliases
-SignFn = Callable[[bytes], str]          # transport signer (RSA-PSS in prod; HMAC stub in tests)
-BroadcastFn = Callable[[dict], None]     # e.g., PeerManager.broadcast_envelope
-VerifyFn = Callable[[dict], bool]        # given an envelope, verify sig with sender's pinned pubkey
-
+# -------------------------------
+# Local user lifecycle → emit gossip
+# -------------------------------
 async def on_user_local_join(
-    user_id: str, 
+    user_id: str,
     meta: dict,
     *,
     my_server_id: str,
+    user_locations: Dict[str, str],
     sign_transport: SignFn,
-    broadcast: BroadcastFn,)->dict:
-    
-    """
-    Called when a local user connects.
-    Builds and broadcasts a USER_ADVERTISE envelope.
-    """
-    payload = {"user_id": user_id, "server_id": my_server_id, "meta": meta or {}}
-    
-    frame = build_frame("USER_ADVERTISE", my_server_id, "*", payload)
-    env = sign_frame_in_place(frame, sign_transport)
+    broadcast: BroadcastFn,
+) -> dict:
+    """Called when a local user connects.
 
-    # optimistic update for our own table
+    Builds and broadcasts USER_ADVERTISE, and optimistically updates user_locations[user_id] = "local".
+    Per spec, payload carries { user_id, server_id, meta }.
+    """
+    if not user_id:
+        raise ValueError("user_id is required")
+
+    payload = {"user_id": user_id, "server_id": my_server_id, "meta": meta or {}}
+    env = sign_frame_in_place(build_frame("USER_ADVERTISE", my_server_id, "*", payload), sign_transport)
+
+    # Optimistic local update: we are the hosting server for this user
     user_locations[user_id] = "local"
 
     broadcast(env)
-    log.info("Advertise user join: %s", user_id)
+    log.info("Advertised local join: %s", user_id)
     return env
 
-async def on_user_local_leave(user_id: str, *,
+
+async def on_user_local_leave(
+    user_id: str,
+    *,
     my_server_id: str,
+    user_locations: Dict[str, str],
     sign_transport: SignFn,
-    broadcast: BroadcastFn)->dict:
-    
+    broadcast: BroadcastFn,
+) -> dict:
+    """Called when a local user disconnects.
+
+    Builds and broadcasts USER_REMOVE. We DO NOT immediately delete our local mapping here;
+    the hosting server is us, and routers should treat deliveries accordingly. However, for simplicity
+    in this implementation we eagerly pop the mapping because we know the user is gone.
     """
-    Called when a local user disconnects.
-    Builds and broadcasts a USER_REMOVE envelope.
-    """
+    if not user_id:
+        raise ValueError("user_id is required")
 
     payload = {"user_id": user_id, "server_id": my_server_id}
-    
-    frame = build_frame("USER_REMOVE", my_server_id, "*", payload)
-    env = sign_frame_in_place(frame, sign_transport)    
+    env = sign_frame_in_place(build_frame("USER_REMOVE", my_server_id, "*", payload), sign_transport)
+
+    # Eagerly remove local presence since we are the hosting server and the user disconnected
+    user_locations.pop(user_id, None)
 
     broadcast(env)
-    log.info("Advertise user leave: %s", user_id)
+    log.info("Advertised local leave: %s", user_id)
     return env
 
+
 # -------------------------------
-# gossip handlers
+# Gossip handlers (ingress from peer servers)
 # -------------------------------
 
 def handle_user_advertise(
     env: dict,
     *,
     my_server_id: str,
+    user_locations: Dict[str, str],
     verify_from_server: VerifyFn,
     fanout: BroadcastFn,
 ) -> bool:
-    """
-    Process a USER_ADVERTISE from another server.
-    Updates user_locations and fans out unchanged envelope.
+    """Process a USER_ADVERTISE from another server.
+
+    Rules (spec §8.2):
+      1) Verify transport signature using the announcing server's pinned key.
+      2) Require payload shape: user_id (UUID), server_id (UUID), meta (object)
+      3) Update mapping: user_locations[user_id] = server_id unless server_id == my_server_id → "local"
+      4) Forward the envelope unchanged (gossip fan-out)
     """
     if env.get("type") != "USER_ADVERTISE":
         return False
+
     if not verify_from_server(env):
         log.warning("Rejected USER_ADVERTISE (bad sig) from %s", env.get("from"))
         return False
 
-    payload = env["payload"]
-    uid, hosting_sid = payload["user_id"], payload["server_id"]
+    # Basic shape enforcement
+    p = env.get("payload") or {}
+    uid = p.get("user_id")
+    hosting_sid = p.get("server_id")
+    if not (is_uuid_v4(hosting_sid) and isinstance(p.get("meta", {}), dict) and uid):
+        log.warning("Rejected USER_ADVERTISE (bad shape)")
+        return False
+
+    # Optional sanity: require that the sender matches hosting_sid
+    frm = env.get("from")
+    if is_uuid_v4(frm) and frm != hosting_sid:
+        log.debug("USER_ADVERTISE from %s claims server_id=%s; accepting but logging.", frm, hosting_sid)
+
     user_locations[uid] = "local" if hosting_sid == my_server_id else hosting_sid
+
+    # Fan-out unchanged; duplicate-suppression is handled at peers/transport layer
     fanout(env)
-    log.info("Processed USER_ADVERTISE for %s hosted on %s", uid, hosting_sid)
+    log.info("Accepted USER_ADVERTISE: %s hosted on %s", uid, hosting_sid)
     return True
 
 
@@ -89,29 +154,56 @@ def handle_user_remove(
     env: dict,
     *,
     my_server_id: str,
+    user_locations: Dict[str, str],
     verify_from_server: VerifyFn,
     fanout: BroadcastFn,
 ) -> bool:
-    """
-    Process a USER_REMOVE with guarded removal.
-    Only accept if the hosting server matches current mapping.
+    """Process a USER_REMOVE with guarded removal (spec §8.2).
+
+    Only remove if our current mapping still points to that server. This prevents a stale or malicious
+    remove from a non-hosting server from wiping presence.
     """
     if env.get("type") != "USER_REMOVE":
         return False
+
     if not verify_from_server(env):
         log.warning("Rejected USER_REMOVE (bad sig) from %s", env.get("from"))
         return False
 
-    payload = env["payload"]
-    uid, hosting_sid = payload["user_id"], payload["server_id"]
+    p = env.get("payload") or {}
+    uid = p.get("user_id")
+    hosting_sid = p.get("server_id")
+
+    if not (uid and is_uuid_v4(hosting_sid)):
+        log.warning("Rejected USER_REMOVE (bad shape)")
+        return False
 
     current = user_locations.get(uid)
-    if current in ("local", hosting_sid):
+
+    # Guarded removal per spec: only remove if the mapping still points to that server
+    if current == hosting_sid or (current == "local" and hosting_sid == my_server_id):
         user_locations.pop(uid, None)
         fanout(env)
-        log.info("Processed USER_REMOVE for %s hosted on %s", uid, hosting_sid)
+        log.info("Accepted USER_REMOVE: %s (was hosted on %s)", uid, hosting_sid)
         return True
 
-    log.debug("Ignored USER_REMOVE for %s (not hosted on %s)", uid, hosting_sid)
+    log.debug("Ignored USER_REMOVE for %s (current=%s, claimed_host=%s)", uid, current, hosting_sid)
     return False
 
+
+# -------------------------------
+# Maintenance helpers
+# -------------------------------
+
+def purge_by_hosting_server(hosting_sid: str, user_locations: Dict[str, str]) -> int:
+    """Remove all users mapped to the given hosting server.
+
+    Intended for use when a peer link is declared dead. This is optional; the spec allows
+    lazy correction on delivery failure or new gossip. Returning the count can help log metrics.
+    """
+    to_delete: list[str] = [u for u, sid in user_locations.items() if sid == hosting_sid]
+    for u in to_delete:
+        user_locations.pop(u, None)
+    if to_delete:
+        log.warning("Purged %d user(s) hosted on dead server %s", len(to_delete), hosting_sid)
+    return len(to_delete)

--- a/socp/core/proto.py
+++ b/socp/core/proto.py
@@ -22,13 +22,13 @@ class ProtocolError(Exception):
 ERROR_CODES = {"USER_NOT_FOUND","INVALID_SIG","BAD_KEY","TIMEOUT","UNKNOWN_TYPE","NAME_IN_USE"}
 
 def now_ms() -> int:
-    return int(time()*1000)
+    return int(time.time()*1000)
 
 def build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
     return {"type": type, 
             "from": from_, 
             "to": to, 
-            "ts": int(time()*1000), 
+            "ts": int(time.time()*1000), 
             "payload": payload,
             "sig": ""}
 

--- a/socp/core/proto.py
+++ b/socp/core/proto.py
@@ -1,6 +1,8 @@
 
 from pydantic import BaseModel, Field
-from typing import Any, Literal, Dict
+from typing import Any, Dict, Tuple
+import time, uuid, base64, json
+from typing import Callable, Union
 
 class Envelope(BaseModel):
     type: str
@@ -10,8 +12,128 @@ class Envelope(BaseModel):
     payload: Dict[str, Any]
     sig: str = ""
 
+class ProtocolError(Exception):
+    """Exception carrying one of ERROR_CODES for validation/verification failures."""
+    def __init__(self, code: str, message: str = ""):
+        super().__init__(message or code)
+        self.code = code
+        self.message = message or code
+        
 ERROR_CODES = {"USER_NOT_FOUND","INVALID_SIG","BAD_KEY","TIMEOUT","UNKNOWN_TYPE","NAME_IN_USE"}
 
+def now_ms() -> int:
+    return int(time()*1000)
+
 def build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
-    from time import time
-    return {"type": type, "from": from_, "to": to, "ts": int(time()*1000), "payload": payload, "sig": ""}
+    return {"type": type, 
+            "from": from_, 
+            "to": to, 
+            "ts": int(time()*1000), 
+            "payload": payload,
+            "sig": ""}
+
+# Spec: all Server/User IDs are UUID v4 (except that during bootstrap, `to` may be "IP:port")
+def is_uuid_v4(s: str) -> bool:
+    try:
+        u = uuid.UUID(str(s))
+        return u.version == 4
+    except Exception:
+        return False
+
+# Spec: all binary blobs in JSON are base64url (unpadded)
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+def b64url_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+# Canonicalise payload for transport signature: sorted keys, no spaces
+def canonical_payload_bytes(payload: Dict[str, Any]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+# Transport signing interface (wire to real RSA-4096 PSS(SHA-256) in your crypto layer)
+SignFn  = Callable[[bytes], str]           # returns base64url(signature)
+VerifyFn = Callable[[bytes, str], bool]    # (data, base64url(sig)) -> bool
+
+# very light IP:port check for introducer/bootstrap special case (leave real validation to networking layer)
+def _is_ip_port(s: str) -> bool:
+    if ":" not in s:
+        return False
+    host, port = s.rsplit(":", 1)
+    if not host or not port.isdigit():
+        return False
+    return True
+
+def validate_envelope(
+    env: Union[Dict[str, Any], Envelope],
+    *,
+    allow_ip_port_to: bool = False,
+    expect_sig: bool = False,
+) -> None:
+    """
+    Raise ProtocolError with an ERROR_CODES code if invalid.
+    Does NOT verify the cryptographic signature; see verify_envelope().
+    """
+    e = env.model_dump(by_alias=True) if isinstance(env, Envelope) else dict(env)
+
+    # minimal shape/type checks
+    for k in ("type", "from", "to", "ts", "payload", "sig"):
+        if k not in e:
+            raise ProtocolError("UNKNOWN_TYPE", f"Missing required field: {k}")
+    if not isinstance(e["type"], str) or not e["type"]:
+        raise ProtocolError("UNKNOWN_TYPE", "Invalid or empty 'type'")
+    if not isinstance(e["ts"], int):
+        raise ProtocolError("BAD_KEY", "'ts' must be an integer (ms)")
+    if not isinstance(e["payload"], dict):
+        raise ProtocolError("BAD_KEY", "'payload' must be an object")
+
+    # identifier rules: from = UUIDv4; to = UUIDv4 or "*" (or IP:port when explicitly allowed)
+    if not is_uuid_v4(e["from"]):
+        raise ProtocolError("BAD_KEY", "Invalid 'from' (must be UUID v4)")
+    to_ok = e["to"] == "*" or is_uuid_v4(e["to"]) or (allow_ip_port_to and _is_ip_port(e["to"]))
+    if not to_ok:
+        raise ProtocolError("BAD_KEY", "Invalid 'to' (must be UUID v4, '*', or IP:port when allowed)")
+
+    # signature presence policy (cryptographic correctness is checked separately)
+    if expect_sig and not e.get("sig"):
+        raise ProtocolError("INVALID_SIG", "Signature required but missing")
+
+def sign_frame_in_place(frame: Dict[str, Any], sign_transport: SignFn) -> Dict[str, Any]:
+    """
+    Computes and sets the transport signature over the canonicalised payload.
+    Mutates and returns the same dict produced by build_frame(...).
+    """
+    if not isinstance(frame, dict) or "payload" not in frame:
+        raise ProtocolError("BAD_KEY", "Frame shape is invalid for signing")
+    frame["sig"] = sign_transport(canonical_payload_bytes(frame["payload"]))
+    return frame
+
+def verify_envelope(
+    env: Union[Dict[str, Any], Envelope],
+    verify_transport: VerifyFn,
+    *,
+    allow_ip_port_to: bool = False,
+    expect_sig: bool = True
+) -> Tuple[bool, Union[str, None]]:
+    """
+    Validate structure & IDs and verify signature.
+    Returns (ok, error_code_or_None). On failure, error_code is from ERROR_CODES.
+    """
+    try:
+        # structural + policy checks first
+        validate_envelope(env, allow_ip_port_to=allow_ip_port_to, expect_sig=expect_sig)
+
+        e = env.model_dump(by_alias=True) if isinstance(env, Envelope) else env
+        sig = e.get("sig", "")
+        if sig:
+            ok = verify_transport(canonical_payload_bytes(e["payload"]), sig)
+            if not ok:
+                return (False, "INVALID_SIG")
+        # If sig not present and not expected, it’s fine; validate_envelope already enforced presence when needed.
+        return (True, None)
+    except ProtocolError as pe:
+        # Map to known ERROR_CODES (already enforced), fall back to BAD_KEY if unknown
+        code = pe.code if pe.code in ERROR_CODES else "BAD_KEY"
+        return (False, code)
+

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -1,0 +1,169 @@
+import asyncio
+import time
+import uuid
+import types
+import pytest
+
+# The module under test
+# from socp.core.peers import PeerManager, Link
+from socp.core import peers
+# ---- helpers ----
+
+class DummySigner:
+    def __call__(self, payload_bytes: bytes):
+        return "dummysig"
+
+
+def mk_uuid() -> str:
+    # UUID v4
+    return str(uuid.uuid4())
+
+
+def ts_ms() -> int:
+    return int(time.time() * 1000)
+
+
+# ---- fixtures ----
+
+@pytest.fixture()
+def signer():
+    return DummySigner()
+
+
+@pytest.fixture()
+def pm(signer):
+    # Use a fixed now() so we can deterministically age links
+    t = {"now": ts_ms()}
+
+    def now_fixed():
+        return t["now"]
+
+    m = peers.PeerManager(my_server_id=mk_uuid(), sign_transport=signer, now=now_fixed)
+    m._timebox = t  # stash for tests to mutate clock
+    return m
+
+
+# ---- tests ----
+
+def test_placeholder_rekeys_on_server_welcome(pm):
+    """A placeholder link ('host:port') is rekeyed to the introducer's UUID after WELCOME."""
+    host, port = "203.0.113.21", 1212
+    placeholder = f"{host}:{port}"
+
+    # Seed placeholder link as bootstrap() does
+    link = peers.Link(server_id=placeholder, host=host, port=port, pubkey_b64="PUBKEY", send=lambda _: None)
+    pm.server_links[placeholder] = link
+    pm.server_addrs[placeholder] = (host, port)
+    pm._placeholders.add(placeholder)
+
+    introducer_id = mk_uuid()
+
+    env_welcome = {
+        "type": "SERVER_WELCOME",
+        "from": introducer_id,
+        "to": pm.my_server_id,
+        "ts": ts_ms(),
+        "payload": {
+            "assigned_id": pm.my_server_id,  # unchanged
+            "clients": [
+                {"user_id": "user-A", "host": host, "port": port, "pubkey": "..."},
+            ],
+        },
+        "sig": "...",
+    }
+
+    pm.on_server_frame(env_welcome)
+
+    # Placeholder should be gone, replaced by real UUID key
+    assert placeholder not in pm.server_links
+    assert introducer_id in pm.server_links
+
+    new_link = pm.server_links[introducer_id]
+    assert new_link.server_id == introducer_id
+    assert pm.server_addrs[introducer_id] == (host, port)
+
+    # Presence seeding
+    assert pm.user_locations.get("user-A") == introducer_id
+
+
+def test_server_announce_registers_and_updates(pm):
+    """SERVER_ANNOUNCE registers address and updates existing Link fields."""
+    peer_id = mk_uuid()
+
+    # First announce -> create link
+    env1 = {
+        "type": "SERVER_ANNOUNCE",
+        "from": peer_id,
+        "to": "*",
+        "ts": ts_ms(),
+        "payload": {"host": "192.0.2.10", "port": 9001, "pubkey": "K1"},
+        "sig": "...",
+    }
+    pm.on_server_frame(env1)
+
+    assert peer_id in pm.server_links
+    assert pm.server_addrs[peer_id] == ("192.0.2.10", 9001)
+
+    link = pm.server_links[peer_id]
+    assert link.pubkey_b64 == "K1"
+    last_seen_1 = link.last_seen_ms
+
+    # Second announce with new address/key -> updates existing link
+    env2 = {
+        "type": "SERVER_ANNOUNCE",
+        "from": peer_id,
+        "to": "*",
+        "ts": ts_ms(),
+        "payload": {"host": "198.51.100.77", "port": 7777, "pubkey": "K2"},
+        "sig": "...",
+    }
+    pm.on_server_frame(env2)
+
+    link2 = pm.server_links[peer_id]
+    assert link2.host == "198.51.100.77"
+    assert link2.port == 7777
+    assert link2.pubkey_b64 == "K2"
+    assert pm.server_addrs[peer_id] == ("198.51.100.77", 7777)
+    assert link2.last_seen_ms >= last_seen_1
+
+
+def test_tick_health_marks_dead_after_45s(pm):
+    # Create a peer and set last_seen far in the past
+    peer_id = mk_uuid()
+    link = peers.Link(server_id=peer_id, host="192.0.2.1", port=9100, pubkey_b64="K", send=lambda _: None)
+    pm.server_links[peer_id] = link
+
+    # Move clock forward 46s
+    pm._timebox["now"] += 46_000
+
+    pm.tick_health(timeout_s=45.0)
+
+    assert pm.server_links[peer_id].is_alive is False
+    assert pm.server_links[peer_id].reconnecting is True
+
+
+def test_heartbeat_sends_only_to_uuid_peers(event_loop, pm, monkeypatch):
+    # Add one UUID peer and one placeholder peer
+    uuid_peer = mk_uuid()
+    placeholder = "198.51.100.1:9001"
+
+    sent = {"uuid": 0, "placeholder": 0}
+
+    def send_uuid(_):
+        sent["uuid"] += 1
+
+    def send_placeholder(_):
+        sent["placeholder"] += 1
+
+    pm.server_links[uuid_peer] = peers.Link(server_id=uuid_peer, host="h", port=1, pubkey_b64="K", send=send_uuid)
+    pm.server_links[placeholder] = peers.Link(server_id=placeholder, host="h2", port=2, pubkey_b64="K2", send=send_placeholder)
+
+    # Run one iteration of the internal loop body by calling the private helper directly
+    # (we don't want to actually sleep here). We'll copy the relevant snippet.
+    for sid, link in list(pm.server_links.items()):
+        if link.is_alive and len(sid) == 36 and sid.count("-") == 4:  # crude uuid v4 check mirrors is_uuid_v4
+            hb = pm.make_heartbeat(sid)
+            link.send(hb)
+
+    assert sent["uuid"] == 1
+    assert sent["placeholder"] == 0

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,0 +1,386 @@
+# tests/test_presence.py
+from __future__ import annotations
+import asyncio
+from uuid import uuid4
+import pytest
+
+import socp.core.presence as presence
+
+
+# -----------------------------
+# Utilities / fixtures
+# -----------------------------
+
+@pytest.fixture
+def uuids():
+    """Fresh UUIDs for each test run."""
+    return {
+        "server_my": str(uuid4()),
+        "server_peer": str(uuid4()),
+        "user": str(uuid4()),
+    }
+
+
+@pytest.fixture
+def user_locations():
+    """Shared mapping the module under test mutates."""
+    return {}
+
+
+@pytest.fixture
+def calls():
+    """Collects broadcast/fanout calls for assertions."""
+    return {"broadcasts": [], "fanouts": []}
+
+
+@pytest.fixture
+def broadcast(calls):
+    def _b(env: dict) -> None:
+        calls["broadcasts"].append(env)
+    return _b
+
+
+@pytest.fixture
+def fanout(calls):
+    def _f(env: dict) -> None:
+        calls["fanouts"].append(env)
+    return _f
+
+
+@pytest.fixture
+def sign_transport():
+    """Trivial signer that returns a deterministic string."""
+    return lambda b: "stub-transport-sig"
+
+
+@pytest.fixture(autouse=True)
+def stub_build_and_sign(monkeypatch):
+    """
+    By default, stub proto.build_frame and proto.sign_frame_in_place
+    to keep tests self-contained and avoid needing real crypto.
+    """
+    def fake_build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
+        # Minimal shape + deterministic ts for assertions
+        return {
+            "type": type,
+            "from": from_,
+            "to": to,
+            "ts": 1700000000000,   # any int ms
+            "payload": payload,
+            "sig": "",
+        }
+
+    def fake_sign_frame_in_place(env: dict, sign_fn) -> dict:
+        # "Sign" only the payload per spec; just mark sig field
+        env = dict(env)
+        env["sig"] = sign_fn(repr(env["payload"]).encode("utf-8"))
+        return env
+
+    monkeypatch.setattr(presence, "build_frame", fake_build_frame)
+    monkeypatch.setattr(presence, "sign_frame_in_place", fake_sign_frame_in_place)
+
+
+# -----------------------------
+# Local events → emits gossip
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_on_user_local_join_updates_and_broadcasts(
+    uuids, user_locations, sign_transport, broadcast, calls
+):
+    """
+    When a local user connects:
+      - Build & sign USER_ADVERTISE
+      - Optimistically set user_locations[user] = "local"
+      - Broadcast the envelope unchanged
+    """
+    env = await presence.on_user_local_join(
+        user_id=uuids["user"],
+        meta={"display_name": "Alice"},
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        sign_transport=sign_transport,
+        broadcast=broadcast,
+    )
+
+    assert user_locations[uuids["user"]] == "local"
+    assert env["type"] == "USER_ADVERTISE"
+    assert env["from"] == uuids["server_my"]
+    assert env["to"] == "*"
+    assert env["payload"]["user_id"] == uuids["user"]
+    assert env["payload"]["server_id"] == uuids["server_my"]
+    assert isinstance(env["ts"], int)
+    assert env["sig"] == "stub-transport-sig"
+
+    # Broadcast called exactly once with the same envelope
+    assert calls["broadcasts"] == [env]
+
+
+@pytest.mark.asyncio
+async def test_on_user_local_leave_removes_and_broadcasts(
+    uuids, user_locations, sign_transport, broadcast, calls
+):
+    """
+    When a local user disconnects:
+      - Build & sign USER_REMOVE
+      - Eagerly remove user from user_locations
+      - Broadcast removal
+    """
+    # Pre-populate as "local" to simulate a connected user
+    user_locations[uuids["user"]] = "local"
+
+    env = await presence.on_user_local_leave(
+        user_id=uuids["user"],
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        sign_transport=sign_transport,
+        broadcast=broadcast,
+    )
+
+    assert uuids["user"] not in user_locations
+    assert env["type"] == "USER_REMOVE"
+    assert env["payload"]["user_id"] == uuids["user"]
+    assert env["payload"]["server_id"] == uuids["server_my"]
+    assert calls["broadcasts"] == [env]
+
+
+# -----------------------------
+# Incoming gossip: USER_ADVERTISE
+# -----------------------------
+
+def test_handle_user_advertise_valid_updates_and_fanouts(
+    uuids, user_locations, fanout, calls
+):
+    """
+    A valid USER_ADVERTISE from a peer server:
+      - verify_from_server True → accept
+      - update mapping to hosting server (unless it's us → 'local')
+      - fanout unchanged
+    """
+    env = {
+        "type": "USER_ADVERTISE",
+        "from": uuids["server_peer"],
+        "to": "*",
+        "ts": 1700000100000,
+        "payload": {
+            "user_id": uuids["user"],
+            "server_id": uuids["server_peer"],
+            "meta": {"dn": "Alice"},
+        },
+        "sig": "ok",
+    }
+
+    def verify_from_server(_env):  # accept
+        return True
+
+    accepted = presence.handle_user_advertise(
+        env,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_from_server,
+        fanout=fanout,
+    )
+
+    assert accepted is True
+    assert user_locations[uuids["user"]] == uuids["server_peer"]
+    assert calls["fanouts"] == [env]
+
+
+def test_handle_user_advertise_bad_sig_rejected(uuids, user_locations, fanout, calls):
+    """
+    If verify fails, the advertise must be ignored and not faned-out.
+    """
+    env = {
+        "type": "USER_ADVERTISE",
+        "from": uuids["server_peer"],
+        "to": "*",
+        "ts": 1700000100000,
+        "payload": {"user_id": uuids["user"], "server_id": uuids["server_peer"], "meta": {}},
+        "sig": "bad",
+    }
+
+    def verify_from_server(_env):
+        return False
+
+    accepted = presence.handle_user_advertise(
+        env,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_from_server,
+        fanout=fanout,
+    )
+    assert accepted is False
+    assert uuids["user"] not in user_locations
+    assert calls["fanouts"] == []
+
+
+def test_handle_user_advertise_bad_shape_rejected(uuids, user_locations, fanout, calls, monkeypatch):
+    """
+    If payload shape is wrong (e.g., missing/invalid meta or server_id not a UUID v4),
+    the advertise is rejected.
+    """
+    env = {
+        "type": "USER_ADVERTISE",
+        "from": uuids["server_peer"],
+        "to": "*",
+        "ts": 1700000100000,
+        "payload": {"user_id": uuids["user"], "server_id": "not-a-uuid", "meta": {}},
+        "sig": "ok",
+    }
+
+    def verify_from_server(_env):  # signature ok but shape invalid
+        return True
+
+    # Force is_uuid_v4 to behave realistically
+    monkeypatch.setattr(presence, "is_uuid_v4", lambda v: False)
+
+    accepted = presence.handle_user_advertise(
+        env,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_from_server,
+        fanout=fanout,
+    )
+    assert accepted is False
+    assert uuids["user"] not in user_locations
+    assert calls["fanouts"] == []
+
+
+# -----------------------------
+# Incoming gossip: USER_REMOVE (guarded removal)
+# -----------------------------
+
+def test_handle_user_remove_only_removes_if_mapping_matches(
+    uuids, user_locations, fanout, calls
+):
+    """
+    Guarded removal:
+      - If we believe the user is on server_peer and removal claims server_peer → remove.
+      - If mapping points somewhere else → ignore.
+    """
+    # Case 1: mapping matches → remove
+    user_locations[uuids["user"]] = uuids["server_peer"]
+
+    env_good = {
+        "type": "USER_REMOVE",
+        "from": uuids["server_peer"],
+        "to": "*",
+        "ts": 1700000200000,
+        "payload": {"user_id": uuids["user"], "server_id": uuids["server_peer"]},
+        "sig": "ok",
+    }
+
+    def verify_ok(_env): return True
+
+    accepted = presence.handle_user_remove(
+        env_good,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_ok,
+        fanout=fanout,
+    )
+    assert accepted is True
+    assert uuids["user"] not in user_locations
+    assert calls["fanouts"][-1] == env_good  # was fanned out
+
+    # Case 2: mapping doesn't match → ignore
+    other_user = str(uuid4())
+    user_locations[other_user] = uuids["server_my"]  # local
+
+    env_wrong_host = {
+        "type": "USER_REMOVE",
+        "from": uuids["server_peer"],
+        "to": "*",
+        "ts": 1700000200500,
+        "payload": {"user_id": other_user, "server_id": uuids["server_peer"]},
+        "sig": "ok",
+    }
+
+    accepted2 = presence.handle_user_remove(
+        env_wrong_host,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_ok,
+        fanout=fanout,
+    )
+    assert accepted2 is False
+    assert user_locations[other_user] == "local"
+
+
+def test_handle_user_remove_bad_sig_or_shape_rejected(uuids, user_locations, fanout, calls):
+    """
+    If signature fails OR payload shape invalid, ignore and do not mutate mapping.
+    """
+    user_locations[uuids["user"]] = uuids["server_peer"]
+
+    env = {
+        "type": "USER_REMOVE",
+        "from": uuids["server_peer"],
+        "to": "*",
+        "ts": 1700000200000,
+        "payload": {"user_id": uuids["user"], "server_id": "not-a-uuid"},
+        "sig": "bad",
+    }
+
+    def verify_fail(_env): return False
+
+    accepted = presence.handle_user_remove(
+        env,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_fail,
+        fanout=fanout,
+    )
+    assert accepted is False
+    assert user_locations[uuids["user"]] == uuids["server_peer"]
+    assert calls["fanouts"] == []
+
+
+def test_handle_user_remove_local_mapping_guarded(uuids, user_locations, fanout, calls):
+    """
+    Special case: if our mapping is 'local' and the remove claims our own server_id,
+    we should accept and remove.
+    """
+    user_locations[uuids["user"]] = "local"
+
+    env = {
+        "type": "USER_REMOVE",
+        "from": uuids["server_my"],
+        "to": "*",
+        "ts": 1700000200001,
+        "payload": {"user_id": uuids["user"], "server_id": uuids["server_my"]},
+        "sig": "ok",
+    }
+
+    def verify_ok(_env): return True
+
+    accepted = presence.handle_user_remove(
+        env,
+        my_server_id=uuids["server_my"],
+        user_locations=user_locations,
+        verify_from_server=verify_ok,
+        fanout=fanout,
+    )
+    assert accepted is True
+    assert uuids["user"] not in user_locations
+
+
+# -----------------------------
+# Maintenance helper
+# -----------------------------
+
+def test_purge_by_hosting_server_removes_only_those_users(uuids):
+    """
+    purge_by_hosting_server(host) should remove all users mapped to that host
+    and return the count; unrelated entries remain.
+    """
+    ul = {
+        str(uuid4()): uuids["server_peer"],
+        str(uuid4()): uuids["server_peer"],
+        str(uuid4()): uuids["server_my"],
+        str(uuid4()): "local",
+    }
+    removed = presence.purge_by_hosting_server(uuids["server_peer"], ul)
+    assert removed == 2
+    # Ensure nothing mapped to server_peer remains
+    assert all(sid != uuids["server_peer"] for sid in ul.values())


### PR DESCRIPTION
# feat(core): bootstrap, announce, and signed presence gossip (SOCP v1.3)

## Summary
- [x] **Module / scope:** `socp/core/peers.py`, `socp/core/presence.py`, partial updates to `socp/core/proto.py`, `configs/bootstrap.yaml`  
- [x] **Linked issue(s):** `feat/peers-presence` (Bootstrap + announce + signed presence gossip per SOCP v1.3)

---

## What changed

### Core Functionality

- **Server Bootstrap & Announce (SOCP §8.1)**  
  - Loads introducers from `configs/bootstrap.yaml` (3 entries; local test keys).  
  - Sends `SERVER_HELLO_JOIN` to an introducer and handles `SERVER_WELCOME` (rekeys placeholder `"host:port"` to assigned `server_id`, seeds presence from `clients`).  
  - Registers/updates peers on `SERVER_ANNOUNCE` and stores `server_addrs` + pinned `pubkey`.

- **Presence Gossip (SOCP §8.2)**  
  - On local join → builds & signs `USER_ADVERTISE`; updates `user_locations[user] = "local"`; broadcasts.  
  - On local leave → builds & signs `USER_REMOVE`; eagerly removes local mapping; broadcasts.  
  - Incoming gossip: verifies transport sig, checks UUIDv4s, updates `user_locations` on valid `USER_ADVERTISE`, and does **guarded removal** for `USER_REMOVE` (only if our mapping still points to that server). Then fans out unchanged (mesh gossip).

- **Protocol utilities (partial `proto.py`, SOCP §7, §12)**  
  - Added `Envelope` model, `ERROR_CODES`, `ProtocolError`, `build_frame`, `sign_frame_in_place`, `verify_envelope`, `is_uuid_v4`, and base64url helpers.  
  - Canonical payload signing (`sort_keys=True`, compact JSON) for transport `sig`.  
  - Work intentionally paused for the teammate assigned to crypto/wire integration.

- **Config (`configs/bootstrap.yaml`)**
  ```yaml
  bootstrap_servers:
    - host: "127.0.0.1"
      port: 7001
      pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_1"
    - host: "127.0.0.1"
      port: 7002
      pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_2"
    - host: "127.0.0.1"
      port: 7003
      pubkey: "BASE64URL_RSA4096_PUBKEY_OF_INTRODUCER_3"

- **Health (foundation)**  
  - Heartbeat maker and liveness tracking consistent with §8.4/§11 (15s HB / 45s timeout guidance).  
  - Reconnections currently use a stub.

---

## Tests

- [x] Added/updated tests (no `proto` unit tests in this PR):

### **Presence — local events → gossip**
- `test_on_user_local_join_updates_and_broadcasts`: emits signed `USER_ADVERTISE`, sets `"local"`, broadcasts.  
- `test_on_user_local_leave_removes_and_broadcasts`: emits signed `USER_REMOVE`, removes local mapping, broadcasts.

### **Presence — incoming gossip**
- `test_handle_user_advertise_valid_updates_and_fanouts`: accepts valid advertise, updates mapping to hosting server, fans out.  
- `test_handle_user_advertise_bad_sig_rejected`: rejects on failed verification; no fanout.  
- `test_handle_user_advertise_bad_shape_rejected`: rejects when payload/UUID invalid; no fanout.  
- `test_handle_user_remove_only_removes_if_mapping_matches`: guarded removal passes only when mapping matches; otherwise ignored.  
- `test_handle_user_remove_bad_sig_or_shape_rejected`: rejects on bad sig/shape; mapping unchanged.  
- `test_handle_user_remove_local_mapping_guarded`: accepts removal when mapping is `"local"` and `server_id` is ours.  
- `test_purge_by_hosting_server_removes_only_those_users`: maintenance helper removes only users hosted by a given server.

### **Peers / health**
- `test_placeholder_rekeys_on_server_welcome`: converts placeholder `"host:port"` to real UUID on WELCOME; seeds presence.  
- `test_server_announce_registers_and_updates`: registers/updates peer addresses and keys.  
- `test_tick_health_marks_dead_after_45s`: marks link dead and sets `reconnecting=True` after timeout.  
- `test_heartbeat_sends_only_to_uuid_peers`: heartbeats are only sent to real UUID peers.

- [x] `pytest -q` passes locally.

---

## SOCP v1.3 compliance
- [x] Envelope fields present; transport `sig` over canonical payload; `ts` in ms (§7, §12).  
- [x] Presence gossip behavior & guarded removal per §8.2.  
- [x] No server-side decryption of user content (E2EE preserved).  
- [x] Health behavior aligns with §8.4/§11 (HB + 45s timeout).

---

## Backdoor toggle (if applicable)
- [ ] No backdoors in this commit (secure baseline).  
- [ ] Vulnerable variant to be added in a separate branch per assignment phase.

---

## Notes for integrators (reconnection work to finish)

Current reconnect is a **stub** (rebinds `link.send` using `server_addrs` when `reconnecting=True`).  
For production-grade behavior, please add a **ConnectionManager** that:

1. **Connection orchestration**  
   - Dials `wss://{host}:{port}` for a `server_id`.  
   - Handles TLS policy and binds the socket’s `send_json` to `link.send`.

2. **Handshake & verification**  
   - Verifies the pinned transport key (`link.pubkey_b64`) before `link.is_alive = True`.  
   - Optionally sends a lightweight link hello frame.

3. **Inbound routing**  
   - Parses each incoming JSON → verifies transport signature (per §7/§12) → passes valid envelopes to `PeerManager.on_server_frame(env)`.

4. **Lifecycle & backoff**  
   - On disconnection: `is_alive=False`, schedule exponential backoff (1s → 2s → 4s … capped ~60s).  
   - Integrate cleanup callbacks via `on_dead(server_id)`.

5. **Ownership of dialing**  
   - Move reconnect logic out of `_heartbeat_loop()` and into the centralized Connection Manager.  
   - Heartbeats should remain purely for liveness detection.


