### PR TITLE
Crypto: RSA-OAEP/PSS + canonical signing + content signatures (+build_frame)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -36,4 +36,4 @@ Environment flags (default to ON in .env.example):
 
 Clean build: set both to 0 (or unset) and enforce strict checks.
 
-Generated on: 2025-09-27T07:33:58.199436
+Generated on: 2025-09-27T07:33:58.199436   

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ uvloop==0.19.0
 aiosqlite
 click
 pytest
+orjson
+cryptography

--- a/socp/core/.cph/.crypto.py_db46ee3e7b9d08540fb1deb890e9b955.prob
+++ b/socp/core/.cph/.crypto.py_db46ee3e7b9d08540fb1deb890e9b955.prob
@@ -1,0 +1,1 @@
+{"name":"Local: crypto","url":"/Users/alien/Downloads/socp-starter-with-branches/socp/core/crypto.py","tests":[{"id":1759496635635,"input":"","output":""}],"interactive":false,"memoryLimit":1024,"timeLimit":3000,"srcPath":"/Users/alien/Downloads/socp-starter-with-branches/socp/core/crypto.py","group":"local","local":true}

--- a/socp/core/crypto.py
+++ b/socp/core/crypto.py
@@ -83,3 +83,34 @@ def sign_content(privkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str
 def verify_content(pubkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int, sig: bytes) -> bool:
     msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
     return verify_pss_sha256(pubkey_pem, msg, sig)
+# socp/core/crypto.py
+def decrypt_and_verify_dm(sender_pub_pem, recipient_priv_pem, b64_ciphertext, from_id, to_id, ts_ms, b64_content_sig):
+    ct = b64url_to_bytes(b64_ciphertext)
+    sig = b64url_to_bytes(b64_content_sig)
+    if not verify_content(sender_pub_pem, ct, from_id, to_id, ts_ms, sig):
+        return None
+    return rsa_decrypt_oaep(recipient_priv_pem, ct)
+
+from cryptography.hazmat.primitives import serialization
+
+def generate_rsa_keypair(bits: int = 4096):
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
+
+def save_pem(path: str, pem: bytes):
+    with open(path, "wb") as f:
+        f.write(pem)
+
+def load_pem(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -1,0 +1,39 @@
+from socp.core import crypto
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import os
+
+def _gen(bits):
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
+
+def test_decrypt_and_verify_dm():
+    s_priv, s_pub = _gen(4096)
+    r_priv, r_pub = _gen(4096)
+    msg = b"hello"
+    ct = crypto.rsa_encrypt_oaep(r_pub, msg)
+    sig = crypto.sign_content(s_priv, ct, "alice", "bob", 1695800000000)
+    pt = crypto.decrypt_and_verify_dm(s_pub, r_priv, crypto.b64url(ct), "alice","bob",1695800000000, crypto.b64url(sig))
+    assert pt == msg
+    # tamper
+    bad = crypto.decrypt_and_verify_dm(s_pub, r_priv, crypto.b64url(ct+b"!"), "alice","bob",1695800000000, crypto.b64url(sig))
+    assert bad is None
+
+def test_key_policy_boundary():
+    _, pub3072 = _gen(3072)
+    _, pub4096 = _gen(4096)
+    os.environ["VULN_WEAK_KEYS"] = "0"
+    assert crypto.accept_pubkey(pub4096) is True
+    assert crypto.accept_pubkey(pub3072) is False
+    os.environ["VULN_WEAK_KEYS"] = "1"
+    assert crypto.accept_pubkey(pub4096) is True


### PR DESCRIPTION
Base: integrate/client
Compare: feat/crypto-e2ee
Labels: crypto, signing, client
Summary
Implements the cryptographic building blocks and envelope helper required by the SOCP v1.3 spec. This enables the client to send end-to-end encrypted direct messages (DMs) with verifiable content signatures, and prepares transport-level signing for servers. Adds a minimal envelope builder so all messages follow the {type, from, to, ts, payload, sig} shape.
What changed
Crypto primitives
rsa_encrypt_oaep(pub, plaintext) / rsa_decrypt_oaep(priv, ciphertext) (SHA-256 OAEP)
sign_pss_sha256(priv, msg) / verify_pss_sha256(pub, msg, sig) (RSASSA-PSS SHA-256)
Content signatures (DM/group)
sign_content(...) / verify_content(...) over SHA256(ciphertext || from || to || ts)
Convenience: decrypt_and_verify_dm(...) (verify then decrypt)
Canonical JSON (transport signing)
utils.canonical.canonical_bytes(d) → deterministic, sorted-keys JSON bytes
proto.sign_transport(payload, server_priv) / proto.verify_transport(payload, sig, server_pub)
Envelope helper
proto.build_frame(type, from, to, payload, ts?, sig?) → dict with required fields
Key policy (strict by default)
Enforce RSA-4096 with e=65537
Backdoor toggle: VULN_WEAK_KEYS=1 allows RSA-1024 (acceptance only; algorithms unchanged)
Keygen & storage helpers
generate_rsa_keypair(bits=4096) → (priv_pem, pub_pem)
save_pem(path, pem) / load_pem(path) for simple persistence
New/updated files
socp/core/crypto.py — primitives, content sigs, key policy, keygen, helpers
socp/utils/canonical.py — canonical JSON bytes
socp/core/proto.py — build_frame, transport sign/verify helpers
tests/test_crypto.py, tests/test_canonical.py, tests/test_crypto_extra.py — unit tests
How to use (Client owner quick start)
Sending a DM:
ciphertext = crypto.rsa_encrypt_oaep(recipient_pub_pem, msg_bytes)
content_sig = crypto.sign_content(sender_priv_pem, ciphertext, from_id, to_id, ts_ms)
frame = proto.build_frame("MSG_DIRECT", from_id, to_id, {
    "ciphertext": crypto.b64url(ciphertext),
    "content_sig": crypto.b64url(content_sig),
}, ts=ts_ms)
# send frame over WS
Receiving a DM:
pt = crypto.decrypt_and_verify_dm(sender_pub_pem, recipient_priv_pem,
                                  b64_ciphertext, from_id, to_id, ts_ms, b64_content_sig)
if pt is None:
    # signature invalid → drop/alert
else:
    # use plaintext bytes
Testing
CI runs pytest -q. Locally:
export PYTHONPATH=$PWD
pytest -q tests/test_crypto.py tests/test_canonical.py tests/test_crypto_extra.py
Coverage includes:
OAEP round-trip
PSS sign/verify + tamper failure
Content signature happy/tamper
Canonical JSON stability (sorted keys)
Key policy strict vs. weak toggle
Decrypt-and-verify helper happy/tamper
Security & backdoor toggle
Strict mode (default): RSA-4096 + e=65537 enforced in accept_pubkey.
Submission backdoor: set VULN_WEAK_KEYS=1 to accept RSA-1024 (kept OFF in clean release).
Reviewer checklist
 CI green (tests workflow)
 build_frame output matches {type, from, to, ts, payload, sig}
 Tamper tests fail verification (content & transport)
 Key policy: 4096-bit enforced by default; 1024-bit accepted only with env toggle
 No secrets or private keys in repo; helpers are stateless/pure