### PR TITLE
Refine crypto primitives and transport signing utilities

### DIFF
--- a/socp/core/crypto.py
+++ b/socp/core/crypto.py
@@ -1,116 +1,259 @@
-import os, base64
+"""Cryptographic primitives and helpers for SOCP."""
+from __future__ import annotations
+
+import base64
+import binascii
+import os
 from typing import Tuple
-from cryptography.hazmat.primitives.asymmetric import rsa, padding
-from cryptography.hazmat.primitives import hashes, serialization
+
 from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
-def b64url(b: bytes) -> str:
-    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+__all__ = [
+    "b64url",
+    "b64url_to_bytes",
+    "rsa_encrypt_oaep",
+    "rsa_decrypt_oaep",
+    "sign_pss_sha256",
+    "verify_pss_sha256",
+    "accept_pubkey",
+    "content_sig_bytes",
+    "sign_content",
+    "verify_content",
+    "decrypt_and_verify_dm",
+    "generate_rsa_keypair",
+    "save_pem",
+    "load_pem",
+]
 
-def b64url_to_bytes(s: str) -> bytes:
-    pad = "=" * ((4 - len(s) % 4) % 4)
-    return base64.urlsafe_b64decode(s + pad)
+
+# ---------------------------------------------------------------------------
+# Base64 helpers
+# ---------------------------------------------------------------------------
+
+def b64url(data: bytes) -> str:
+    """Return URL-safe base64 without padding."""
+
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def b64url_to_bytes(token: str) -> bytes:
+    """Decode a URL-safe base64 string that may omit padding."""
+
+    pad_len = (-len(token)) % 4
+    return base64.urlsafe_b64decode(token + "=" * pad_len)
+
+
+# ---------------------------------------------------------------------------
+# RSA primitives
+# ---------------------------------------------------------------------------
+
+def _load_public_key(pubkey_pem: bytes) -> rsa.RSAPublicKey:
+    pub = serialization.load_pem_public_key(pubkey_pem)
+    if not isinstance(pub, rsa.RSAPublicKey):
+        raise TypeError("Expected an RSA public key")
+    return pub
+
+
+def _load_private_key(privkey_pem: bytes) -> rsa.RSAPrivateKey:
+    priv = serialization.load_pem_private_key(privkey_pem, password=None)
+    if not isinstance(priv, rsa.RSAPrivateKey):
+        raise TypeError("Expected an RSA private key")
+    return priv
+
 
 def rsa_encrypt_oaep(pubkey_pem: bytes, plaintext: bytes) -> bytes:
-    pub = serialization.load_pem_public_key(pubkey_pem)
+    """Encrypt ``plaintext`` with RSA-OAEP (SHA-256)."""
+
+    pub = _load_public_key(pubkey_pem)
     return pub.encrypt(
         plaintext,
-        padding.OAEP(mgf=padding.MGF1(hashes.SHA256()),
-                     algorithm=hashes.SHA256(),
-                     label=None)
+        padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
     )
+
 
 def rsa_decrypt_oaep(privkey_pem: bytes, ciphertext: bytes) -> bytes:
-    priv = serialization.load_pem_private_key(privkey_pem, password=None)
+    """Decrypt RSA-OAEP ciphertext using ``privkey_pem``."""
+
+    priv = _load_private_key(privkey_pem)
     return priv.decrypt(
         ciphertext,
-        padding.OAEP(mgf=padding.MGF1(hashes.SHA256()),
-                     algorithm=hashes.SHA256(),
-                     label=None)
+        padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
     )
 
-def sign_pss_sha256(privkey_pem: bytes, msg: bytes) -> bytes:
-    priv = serialization.load_pem_private_key(privkey_pem, password=None)
+
+def sign_pss_sha256(privkey_pem: bytes, message: bytes) -> bytes:
+    """Sign ``message`` with RSASSA-PSS using SHA-256."""
+
+    priv = _load_private_key(privkey_pem)
     return priv.sign(
-        msg,
-        padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
-                    salt_length=padding.PSS.MAX_LENGTH),
-        hashes.SHA256()
+        message,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.MAX_LENGTH,
+        ),
+        hashes.SHA256(),
     )
 
-def verify_pss_sha256(pubkey_pem: bytes, msg: bytes, sig: bytes) -> bool:
-    pub = serialization.load_pem_public_key(pubkey_pem)
+
+def verify_pss_sha256(pubkey_pem: bytes, message: bytes, signature: bytes) -> bool:
+    """Verify a RSASSA-PSS signature."""
+
+    pub = _load_public_key(pubkey_pem)
     try:
         pub.verify(
-            sig,
-            msg,
-            padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
-                        salt_length=padding.PSS.MAX_LENGTH),
-            hashes.SHA256()
+            signature,
+            message,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
         )
         return True
     except InvalidSignature:
         return False
 
-def _is_rsa_pubkey_strong(pub) -> bool:
-    if not isinstance(pub, rsa.RSAPublicKey):
-        return False
-    return (pub.key_size >= 4096) and (pub.public_numbers().e == 65537)
 
-def _is_rsa_pubkey_weak_allowed(pub) -> bool:
-    if not isinstance(pub, rsa.RSAPublicKey):
-        return False
-    if os.getenv("VULN_WEAK_KEYS", "0") != "1":
-        return False
-    return pub.key_size >= 1024
+# ---------------------------------------------------------------------------
+# Key acceptance policy
+# ---------------------------------------------------------------------------
+
+_STRICT_EXPONENT = 65537
+_STRICT_KEY_SIZE = 4096
+_WEAK_MIN_KEY_SIZE = 1024
+
+
+def _weak_keys_allowed() -> bool:
+    return os.getenv("VULN_WEAK_KEYS", "0") == "1"
+
+
+def _is_strong_rsa_key(pub: rsa.RSAPublicKey) -> bool:
+    return pub.key_size >= _STRICT_KEY_SIZE and pub.public_numbers().e == _STRICT_EXPONENT
+
+
+def _is_allowed_weak_key(pub: rsa.RSAPublicKey) -> bool:
+    return _weak_keys_allowed() and pub.key_size >= _WEAK_MIN_KEY_SIZE
+
 
 def accept_pubkey(pubkey_pem: bytes) -> bool:
-    pub = serialization.load_pem_public_key(pubkey_pem)
-    return _is_rsa_pubkey_strong(pub) or _is_rsa_pubkey_weak_allowed(pub)
+    """Return ``True`` if the PEM represents an acceptable RSA public key."""
+
+    try:
+        pub = _load_public_key(pubkey_pem)
+    except (ValueError, TypeError):
+        return False
+    return _is_strong_rsa_key(pub) or _is_allowed_weak_key(pub)
+
+
+# ---------------------------------------------------------------------------
+# Content signature helpers
+# ---------------------------------------------------------------------------
 
 def content_sig_bytes(ciphertext: bytes, from_id: str, to_id: str, ts_ms: int) -> bytes:
-    h = hashes.Hash(hashes.SHA256())
-    h.update(ciphertext)
-    h.update(from_id.encode("utf-8"))
-    h.update(to_id.encode("utf-8"))
-    h.update(str(ts_ms).encode("utf-8"))
-    return h.finalize()
+    """Return the SHA-256 digest used for DM/group content signatures."""
 
-def sign_content(privkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int) -> bytes:
-    msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
-    return sign_pss_sha256(privkey_pem, msg)
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(ciphertext)
+    digest.update(from_id.encode("utf-8"))
+    digest.update(to_id.encode("utf-8"))
+    digest.update(str(ts_ms).encode("utf-8"))
+    return digest.finalize()
 
-def verify_content(pubkey_pem: bytes, ciphertext: bytes, from_id: str, to_id: str, ts_ms: int, sig: bytes) -> bool:
-    msg = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
-    return verify_pss_sha256(pubkey_pem, msg, sig)
-# socp/core/crypto.py
-def decrypt_and_verify_dm(sender_pub_pem, recipient_priv_pem, b64_ciphertext, from_id, to_id, ts_ms, b64_content_sig):
-    ct = b64url_to_bytes(b64_ciphertext)
-    sig = b64url_to_bytes(b64_content_sig)
-    if not verify_content(sender_pub_pem, ct, from_id, to_id, ts_ms, sig):
+
+def sign_content(
+    privkey_pem: bytes,
+    ciphertext: bytes,
+    from_id: str,
+    to_id: str,
+    ts_ms: int,
+) -> bytes:
+    """Sign a DM/group payload using the configured content signature format."""
+
+    message = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
+    return sign_pss_sha256(privkey_pem, message)
+
+
+def verify_content(
+    pubkey_pem: bytes,
+    ciphertext: bytes,
+    from_id: str,
+    to_id: str,
+    ts_ms: int,
+    signature: bytes,
+) -> bool:
+    """Verify a DM/group content signature."""
+
+    message = content_sig_bytes(ciphertext, from_id, to_id, ts_ms)
+    return verify_pss_sha256(pubkey_pem, message, signature)
+
+
+def decrypt_and_verify_dm(
+    sender_pub_pem: bytes,
+    recipient_priv_pem: bytes,
+    b64_ciphertext: str,
+    from_id: str,
+    to_id: str,
+    ts_ms: int,
+    b64_content_sig: str,
+) -> bytes | None:
+    """Verify a content signature before decrypting a direct message."""
+
+    try:
+        ciphertext = b64url_to_bytes(b64_ciphertext)
+        signature = b64url_to_bytes(b64_content_sig)
+    except (ValueError, binascii.Error):
         return None
-    return rsa_decrypt_oaep(recipient_priv_pem, ct)
 
-from cryptography.hazmat.primitives import serialization
+    if not verify_content(sender_pub_pem, ciphertext, from_id, to_id, ts_ms, signature):
+        return None
 
-def generate_rsa_keypair(bits: int = 4096):
-    priv = rsa.generate_private_key(public_exponent=65537, key_size=bits)
-    pub = priv.public_key()
-    priv_pem = priv.private_bytes(
+    try:
+        return rsa_decrypt_oaep(recipient_priv_pem, ciphertext)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Keypair generation and persistence helpers
+# ---------------------------------------------------------------------------
+
+def generate_rsa_keypair(bits: int = _STRICT_KEY_SIZE) -> Tuple[bytes, bytes]:
+    """Generate an RSA keypair, defaulting to the strict policy."""
+
+    private_key = rsa.generate_private_key(public_exponent=_STRICT_EXPONENT, key_size=bits)
+    public_key = private_key.public_key()
+
+    priv_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    pub_pem = pub.public_bytes(
+    pub_pem = public_key.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
     return priv_pem, pub_pem
 
-def save_pem(path: str, pem: bytes):
-    with open(path, "wb") as f:
-        f.write(pem)
+
+def save_pem(path: str, pem: bytes) -> None:
+    """Persist a PEM blob to ``path``."""
+
+    with open(path, "wb") as handle:
+        handle.write(pem)
+
 
 def load_pem(path: str) -> bytes:
-    with open(path, "rb") as f:
-        return f.read()
+    """Read a PEM blob from ``path``."""
+
+    with open(path, "rb") as handle:
+        return handle.read()

--- a/socp/core/proto.py
+++ b/socp/core/proto.py
@@ -1,8 +1,26 @@
+"""Transport envelope helpers and signing utilities."""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Mapping, Optional
 
 from pydantic import BaseModel, Field
-from typing import Any, Literal, Dict
+
+from socp.utils.canonical import canonical_bytes
+
+from . import crypto
+
+__all__ = [
+    "Envelope",
+    "build_frame",
+    "sign_transport",
+    "verify_transport",
+]
+
 
 class Envelope(BaseModel):
+    """Pydantic model describing the common transport envelope."""
+
     type: str
     from_: str = Field(alias="from")
     to: str
@@ -10,33 +28,53 @@ class Envelope(BaseModel):
     payload: Dict[str, Any]
     sig: str = ""
 
-ERROR_CODES = {"USER_NOT_FOUND","INVALID_SIG","BAD_KEY","TIMEOUT","UNKNOWN_TYPE","NAME_IN_USE"}
 
-def build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
-    from time import time
-    return {"type": type, "from": from_, "to": to, "ts": int(time()*1000), "payload": payload, "sig": ""}
+ERROR_CODES = {"USER_NOT_FOUND", "INVALID_SIG", "BAD_KEY", "TIMEOUT", "UNKNOWN_TYPE", "NAME_IN_USE"}
 
-# --- Helpers added for crypto transport signing & envelope building ---
-from . import crypto
-from socp.utils.canonical import canonical_bytes
-import base64, time
-from typing import Dict, Any, Optional
 
-def sign_transport(payload: dict, server_priv_pem: bytes) -> str:
-    sig = crypto.sign_pss_sha256(server_priv_pem, canonical_bytes(payload))
-    return crypto.b64url(sig)
+def _require_mapping(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    if not isinstance(data, Mapping):
+        raise TypeError("payload must be a mapping")
+    return data
 
-def verify_transport(payload: dict, sig_b64url: str, server_pub_pem: bytes) -> bool:
+
+def sign_transport(payload: Mapping[str, Any], server_priv_pem: bytes) -> str:
+    """Produce a base64url-encoded transport signature for ``payload``."""
+
+    canonical = canonical_bytes(dict(_require_mapping(payload)))
+    signature = crypto.sign_pss_sha256(server_priv_pem, canonical)
+    return crypto.b64url(signature)
+
+
+def verify_transport(payload: Mapping[str, Any], sig_b64url: str, server_pub_pem: bytes) -> bool:
+    """Verify a base64url transport signature against ``payload``."""
+
     try:
-        sig = crypto.b64url_to_bytes(sig_b64url)
+        signature = crypto.b64url_to_bytes(sig_b64url)
     except Exception:
         return False
-    return crypto.verify_pss_sha256(server_pub_pem, canonical_bytes(payload), sig)
+
+    canonical = canonical_bytes(dict(_require_mapping(payload)))
+    return crypto.verify_pss_sha256(server_pub_pem, canonical, signature)
+
 
 def now_ms() -> int:
+    """Return the current epoch timestamp in milliseconds."""
+
     return int(time.time() * 1000)
 
-def build_frame(msg_type: str, from_id: str, to_id: str, payload: Optional[Dict[str, Any]] = None, *, ts: Optional[int] = None, sig: str = "") -> Dict[str, Any]:
+
+def build_frame(
+    msg_type: str,
+    from_id: str,
+    to_id: str,
+    payload: Optional[Dict[str, Any]] = None,
+    *,
+    ts: Optional[int] = None,
+    sig: str = "",
+) -> Dict[str, Any]:
+    """Construct an envelope following the SOCP {type, from, to, ts, payload, sig} shape."""
+
     if payload is None:
         payload = {}
     if not isinstance(payload, dict):

--- a/socp/utils/canonical.py
+++ b/socp/utils/canonical.py
@@ -1,4 +1,15 @@
+"""Canonical JSON utilities for transport signing."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
 import orjson
 
-def canonical_bytes(d: dict) -> bytes:
-    return orjson.dumps(d, option=orjson.OPT_SORT_KEYS)
+
+def canonical_bytes(payload: Mapping) -> bytes:
+    """Return deterministic JSON bytes with sorted keys and no extra whitespace."""
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping for canonical encoding")
+    return orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)


### PR DESCRIPTION
## Summary
- restructure the crypto primitives to share key-loading helpers, expose a stable API surface, and harden content-signature verification
- tighten the canonical JSON utility with mapping validation to guarantee deterministic signing input
- clean up the transport helpers to reuse canonical signing, validate payload shapes, and document the envelope contract

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e334b7fe0083209e4670eed9f19f60