### PR TITLE
Implement websocket routing core

### DIFF
--- a/socp/cmd/server.py
+++ b/socp/cmd/server.py
@@ -1,6 +1,9 @@
 
-import argparse, asyncio, json, os, logging
-from socp.core import ws, router, peers, presence, proto, store, public, files, crypto
+import argparse
+import asyncio
+import logging
+
+from socp.core import crypto, files, peers, presence, proto, public, router, store, ws
 
 log = logging.getLogger("socp.server")
 
@@ -21,12 +24,10 @@ async def main():
     await public.ensure_public_group()
 
     # Start WS server with a simple on_message callback
-    async def on_message(link, frame_text):
-        # TODO: parse envelope, route, verify, etc.
-        log.info("Received frame: %s", frame_text[:200])
+    router_state = router.Router(cfg["server_id"])
 
     log.info("Starting SOCP server on %s:%d", host, port)
-    await ws.serve(host, port, on_message)
+    await ws.serve(host, port, router_state)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")

--- a/socp/core/proto.py
+++ b/socp/core/proto.py
@@ -1,17 +1,100 @@
 
-from pydantic import BaseModel, Field
-from typing import Any, Literal, Dict
+from __future__ import annotations
+
+from time import time
+from typing import Any, Dict, Mapping, Optional
+
+import json
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+
+class FrameValidationError(ValueError):
+    """Raised when a websocket frame cannot be coerced into an :class:`Envelope`."""
+
 
 class Envelope(BaseModel):
-    type: str
-    from_: str = Field(alias="from")
-    to: str
+    """Typed representation of a SOCP transport envelope."""
+
+    type: str = Field(min_length=1)
+    from_: str = Field(alias="from", min_length=1)
+    to: str = Field(min_length=1)
     ts: int
     payload: Dict[str, Any]
     sig: str = ""
 
-ERROR_CODES = {"USER_NOT_FOUND","INVALID_SIG","BAD_KEY","TIMEOUT","UNKNOWN_TYPE","NAME_IN_USE"}
+    model_config = {"populate_by_name": True, "extra": "forbid"}
 
-def build_frame(type: str, from_: str, to: str, payload: dict) -> dict:
-    from time import time
-    return {"type": type, "from": from_, "to": to, "ts": int(time()*1000), "payload": payload, "sig": ""}
+    @field_validator("ts")
+    @classmethod
+    def _ts_is_positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("timestamp must be positive millisecond epoch")
+        return value
+
+
+ERROR_CODES = {
+    "USER_NOT_FOUND",
+    "INVALID_SIG",
+    "BAD_KEY",
+    "TIMEOUT",
+    "UNKNOWN_TYPE",
+    "NAME_IN_USE",
+    "DUPLICATE",
+}
+
+
+def parse_envelope(raw_frame: str | Mapping[str, Any]) -> Envelope:
+    """Parse and validate a raw websocket frame into an :class:`Envelope`.
+
+    ``raw_frame`` may either be a JSON string or an already decoded mapping.
+    A :class:`FrameValidationError` is raised when validation fails.
+    """
+
+    if isinstance(raw_frame, str):
+        try:
+            decoded: Any = json.loads(raw_frame)
+        except json.JSONDecodeError as exc:  # pragma: no cover - json lib tested elsewhere
+            raise FrameValidationError("frame is not valid JSON") from exc
+    else:
+        decoded = raw_frame
+
+    if not isinstance(decoded, Mapping):
+        raise FrameValidationError("frame payload must be a JSON object")
+
+    try:
+        return Envelope.model_validate(decoded)
+    except ValidationError as exc:  # pragma: no cover - exercised in tests
+        raise FrameValidationError(str(exc)) from exc
+
+
+def build_frame(type: str, from_: str, to: str, payload: Mapping[str, Any]) -> Dict[str, Any]:
+    """Build a JSON-serialisable envelope ready for transport."""
+
+    return {
+        "type": type,
+        "from": from_,
+        "to": to,
+        "ts": int(time() * 1000),
+        "payload": dict(payload),
+        "sig": "",
+    }
+
+
+def make_ack(from_: str, to: str, ref_type: str, ref_ts: int, extra: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    """Create a transport-level acknowledgement frame."""
+
+    payload: Dict[str, Any] = {"ref": ref_type, "ts": ref_ts}
+    if extra:
+        payload.update(extra)
+    return build_frame("ACK", from_, to, payload)
+
+
+def make_error(from_: str, to: str, code: str, message: Optional[str] = None) -> Dict[str, Any]:
+    """Create a transport-level error frame with a canonical payload."""
+
+    if code not in ERROR_CODES:
+        raise ValueError(f"Unknown error code '{code}'")
+    payload: Dict[str, Any] = {"code": code}
+    if message:
+        payload["message"] = message
+    return build_frame("ERROR", from_, to, payload)

--- a/socp/core/router.py
+++ b/socp/core/router.py
@@ -1,34 +1,112 @@
 
-import hashlib, os
-from typing import Tuple
+from __future__ import annotations
 
-SEEN_IDS = set()
+import hashlib
+import json
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Iterable, Literal, Optional
 
-def dedupe_key(ts:int, from_:str, to:str, payload:dict)->str:
-    h = hashlib.sha256(json_bytes(payload)).hexdigest()
-    return f"{ts}|{from_}|{to}|{h}"
+from . import proto
 
-def json_bytes(d:dict)->bytes:
-    import json
-    return json.dumps(d, sort_keys=True, separators=(",",":")).encode("utf-8")
 
-def should_bypass_dedupe(payload: dict) -> bool:
-    # Backdoor toggle: bypass dedupe when VULN_REPLAY=1 and crafted condition holds
-    if os.getenv("VULN_REPLAY","0") != "1": return False
-    # crafted condition: if payload contains key "hops" with value 0
-    return payload.get("hops") == 0
+def _json_bytes(data: Dict[str, object]) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
-def route_to_user(target_u: str, frame: dict, local_users: dict, user_locations: dict) -> Tuple[str, str]:
-    # Dedupe (unless bypassed via backdoor condition)
-    if not should_bypass_dedupe(frame.get("payload", {})):
-        dk = dedupe_key(frame["ts"], frame["from"], frame["to"], frame["payload"])
-        if dk in SEEN_IDS:
-            return ("error", "DUPLICATE")
-        SEEN_IDS.add(dk)
 
-    if target_u in local_users:
-        return ("deliver_local", target_u)
-    dest = user_locations.get(target_u)
-    if dest and dest != "local":
-        return ("forward", dest)
-    return ("error","USER_NOT_FOUND")
+def _dedupe_key(ts: int, from_: str, to: str, payload: Dict[str, object]) -> str:
+    digest = hashlib.sha256(_json_bytes(payload)).hexdigest()
+    return f"{ts}|{from_}|{to}|{digest}"
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    action: Literal["deliver_local", "forward", "error", "drop"]
+    target: Optional[str] = None
+    code: Optional[str] = None
+
+
+class DedupeCache:
+    """Best-effort duplicate suppression cache with TTL-based eviction."""
+
+    def __init__(self, max_age: float = 120.0, max_entries: int = 8192) -> None:
+        self._max_age = max_age
+        self._max_entries = max_entries
+        self._entries: Dict[str, float] = {}
+        self._order: Deque[tuple[float, str]] = deque()
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - self._max_age
+        while self._order and (self._order[0][0] < cutoff or len(self._order) > self._max_entries):
+            _, key = self._order.popleft()
+            self._entries.pop(key, None)
+
+    def mark(self, key: str) -> bool:
+        now = time.time()
+        self._prune(now)
+        if key in self._entries:
+            return False
+        self._entries[key] = now
+        self._order.append((now, key))
+        self._prune(now)
+        return True
+
+
+class Router:
+    """In-memory routing tables for local/remote users and servers."""
+
+    def __init__(self, server_id: str, dedupe_cache: Optional[DedupeCache] = None) -> None:
+        self.server_id = server_id
+        self._dedupe = dedupe_cache or DedupeCache()
+        self.local_users: Dict[str, "Link"] = {}
+        self.server_links: Dict[str, "Link"] = {}
+        self.user_locations: Dict[str, str] = {}
+
+    # -- registration -------------------------------------------------
+    def register_local_user(self, user_id: str, link: "Link") -> None:
+        self.local_users[user_id] = link
+        self.user_locations[user_id] = "local"
+
+    def unregister_local_user(self, user_id: str) -> None:
+        self.local_users.pop(user_id, None)
+        if self.user_locations.get(user_id) == "local":
+            self.user_locations.pop(user_id, None)
+
+    def register_server_link(self, server_id: str, link: "Link", users: Optional[Iterable[str]] = None) -> None:
+        self.server_links[server_id] = link
+        if users:
+            for user in users:
+                self.user_locations[user] = server_id
+
+    def unregister_server_link(self, server_id: str) -> None:
+        self.server_links.pop(server_id, None)
+        for user, location in list(self.user_locations.items()):
+            if location == server_id:
+                self.user_locations.pop(user, None)
+
+    def track_remote_users(self, server_id: str, users: Iterable[str]) -> None:
+        for user in users:
+            self.user_locations[user] = server_id
+
+    # -- routing ------------------------------------------------------
+    def route(self, envelope: proto.Envelope) -> RouteDecision:
+        if envelope.type == "SERVER_DELIVER":
+            key = _dedupe_key(envelope.ts, envelope.from_, envelope.to, envelope.payload)
+            if not self._dedupe.mark(key):
+                return RouteDecision("drop", code="DUPLICATE")
+
+        target_user = envelope.to
+        if target_user in self.local_users:
+            return RouteDecision("deliver_local", target_user)
+
+        server_id = self.user_locations.get(target_user)
+        if server_id and server_id in self.server_links:
+            return RouteDecision("forward", server_id)
+
+        return RouteDecision("error", code="USER_NOT_FOUND")
+
+
+# Forward reference to avoid circular import during runtime type checking.
+class Link:  # pragma: no cover - runtime-only shim for type checkers
+    pass

--- a/socp/core/ws.py
+++ b/socp/core/ws.py
@@ -1,18 +1,177 @@
 
-import asyncio, websockets, logging, json
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from . import presence, proto, router
+
+
 log = logging.getLogger("socp.ws")
 
-class Link:
-    def __init__(self, websocket):
-        self.ws = websocket
 
-    async def send(self, frame: dict):
+class Link:
+    def __init__(self, websocket: websockets.WebSocketServerProtocol) -> None:
+        self.ws = websocket
+        self.identity: Optional[str] = None
+        self.kind: Optional[str] = None  # "user" or "server"
+
+    async def send(self, frame: dict) -> None:
         await self.ws.send(json.dumps(frame))
 
-async def serve(host, port, on_message_cb):
-    async def handler(websocket):
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        await self.ws.close(code=code, reason=reason)
+
+    async def recv_text(self) -> Optional[str]:
+        message = await self.ws.recv()
+        if isinstance(message, str):
+            return message
+        log.warning("Binary frame from %s rejected", self.identity or "unknown")
+        await self.close(code=1003, reason="binary frames not supported")
+        return None
+
+
+async def serve(host: str, port: int, router_state: router.Router) -> None:
+    async def handler(websocket: websockets.WebSocketServerProtocol) -> None:
         link = Link(websocket)
-        async for message in websocket:
-            await on_message_cb(link, message)
+        try:
+            await _handle_connection(link, router_state)
+        except ConnectionClosed:
+            pass
+        except Exception:  # pragma: no cover - defensive logging only
+            log.exception("Unhandled error while processing websocket connection")
+            await link.close(code=1011, reason="internal error")
+
     async with websockets.serve(handler, host, port):
-        await asyncio.Future()  # run forever
+        await asyncio.Future()
+
+
+async def _handle_connection(link: Link, router_state: router.Router) -> None:
+    hello_raw = await link.recv_text()
+    if hello_raw is None:
+        return
+
+    try:
+        hello = proto.parse_envelope(hello_raw)
+    except proto.FrameValidationError as exc:
+        log.warning("Invalid hello frame: %s", exc)
+        await link.close(code=1003, reason="invalid hello")
+        return
+
+    if hello.type == "USER_HELLO":
+        await _accept_user(link, router_state, hello)
+    elif hello.type.startswith("SERVER_HELLO"):
+        await _accept_server(link, router_state, hello)
+    else:
+        await link.send(proto.make_error(router_state.server_id, hello.from_, "UNKNOWN_TYPE"))
+        await link.close(code=1008, reason="unexpected hello type")
+
+
+async def _accept_user(link: Link, router_state: router.Router, hello: proto.Envelope) -> None:
+    user_id = hello.from_
+    if user_id in router_state.local_users:
+        await link.send(proto.make_error(router_state.server_id, user_id, "NAME_IN_USE"))
+        await link.close(code=1008, reason="user already connected")
+        return
+
+    link.identity = user_id
+    link.kind = "user"
+    router_state.register_local_user(user_id, link)
+    try:
+        await presence.on_user_local_join(user_id, hello.payload)
+    except Exception:  # pragma: no cover - presence broadcast best effort
+        log.exception("Presence join hook failed for %s", user_id)
+
+    await link.send(proto.make_ack(router_state.server_id, user_id, hello.type, hello.ts))
+
+    try:
+        async for raw in link.ws:
+            if not isinstance(raw, str):
+                log.warning("Binary frame from user %s", user_id)
+                await link.close(code=1003, reason="binary frames not supported")
+                break
+            if not await _process_frame(router_state, link, raw):
+                break
+    finally:
+        router_state.unregister_local_user(user_id)
+        try:
+            await presence.on_user_local_leave(user_id)
+        except Exception:  # pragma: no cover - presence broadcast best effort
+            log.exception("Presence leave hook failed for %s", user_id)
+
+
+async def _accept_server(link: Link, router_state: router.Router, hello: proto.Envelope) -> None:
+    server_id = hello.from_
+    link.identity = server_id
+    link.kind = "server"
+    advertised_users = hello.payload.get("users") if isinstance(hello.payload, dict) else None
+    if server_id in router_state.server_links:
+        await link.close(code=1008, reason="server already linked")
+        return
+
+    router_state.register_server_link(server_id, link, advertised_users or None)
+    await link.send(proto.make_ack(router_state.server_id, server_id, hello.type, hello.ts))
+
+    try:
+        async for raw in link.ws:
+            if not isinstance(raw, str):
+                log.warning("Binary frame from server %s", server_id)
+                await link.close(code=1003, reason="binary frames not supported")
+                break
+            if not await _process_frame(router_state, link, raw):
+                break
+    finally:
+        router_state.unregister_server_link(server_id)
+
+
+async def _process_frame(router_state: router.Router, link: Link, frame_raw: str) -> bool:
+    try:
+        envelope = proto.parse_envelope(frame_raw)
+    except proto.FrameValidationError as exc:
+        log.warning("Invalid frame from %s: %s", link.identity or "unknown", exc)
+        await link.close(code=1003, reason="invalid frame")
+        return False
+
+    decision = router_state.route(envelope)
+
+    if decision.action == "drop":
+        log.debug("Dropped duplicate frame %s→%s", envelope.from_, envelope.to)
+        return True
+
+    if decision.action == "deliver_local":
+        target_link = router_state.local_users.get(decision.target or "")
+        if not target_link:
+            await link.send(proto.make_error(router_state.server_id, link.identity or "", "USER_NOT_FOUND"))
+            return True
+        deliver = proto.build_frame("USER_DELIVER", envelope.from_, envelope.to, envelope.payload)
+        await target_link.send(deliver)
+        await link.send(
+            proto.make_ack(router_state.server_id, link.identity or envelope.from_, envelope.type, envelope.ts)
+        )
+        return True
+
+    if decision.action == "forward":
+        server_id = decision.target
+        server_link = router_state.server_links.get(server_id or "")
+        if not server_link:
+            await link.send(proto.make_error(router_state.server_id, link.identity or "", "USER_NOT_FOUND"))
+            return True
+        forward = proto.build_frame("SERVER_DELIVER", envelope.from_, envelope.to, envelope.payload)
+        await server_link.send(forward)
+        await link.send(
+            proto.make_ack(router_state.server_id, link.identity or envelope.from_, envelope.type, envelope.ts)
+        )
+        return True
+
+    if decision.action == "error":
+        await link.send(proto.make_error(router_state.server_id, link.identity or envelope.from_, decision.code or "USER_NOT_FOUND"))
+        return True
+
+    log.error("Unhandled routing action %s", decision.action)
+    await link.close(code=1011, reason="routing error")
+    return False

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,5 +1,31 @@
 
+import json
+
+import pytest
+
 from socp.core import proto
+
+
 def test_build_frame_has_fields():
-    f = proto.build_frame("HEARTBEAT","server_a","server_b",{"x":1})
-    assert set(f.keys()) == {"type","from","to","ts","payload","sig"}
+    f = proto.build_frame("HEARTBEAT", "server_a", "server_b", {"x": 1})
+    assert set(f.keys()) == {"type", "from", "to", "ts", "payload", "sig"}
+
+
+def test_parse_envelope_rejects_non_object():
+    with pytest.raises(proto.FrameValidationError):
+        proto.parse_envelope(json.dumps(["not", "an", "object"]))
+
+
+def test_parse_envelope_validates_required_fields():
+    payload = json.dumps({"type": "USER_HELLO", "from": "alice", "to": "server", "ts": 1, "payload": {}})
+    env = proto.parse_envelope(payload)
+    assert env.from_ == "alice"
+    assert env.type == "USER_HELLO"
+
+
+def test_make_ack_and_error_helpers():
+    ack = proto.make_ack("server", "alice", "USER_HELLO", 1234)
+    assert ack["type"] == "ACK"
+    assert ack["payload"]["ref"] == "USER_HELLO"
+    err = proto.make_error("server", "alice", "USER_NOT_FOUND")
+    assert err["payload"]["code"] == "USER_NOT_FOUND"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,19 +1,50 @@
 
-import os
-from socp.core import router
-def test_dedupe_toggle():
-    frame = {"ts":1,"from":"sA","to":"sB","payload":{"hops":1}}
-    res1 = router.route_to_user("alice", frame, {"bob":object()}, {"alice":"local"})
-    # first time should pass through dedupe, mark seen, then deliver_local
-    assert res1[0] in {"deliver_local","forward","error"}
+from socp.core import proto, router
 
-    # replay same frame without bypass -> duplicate
-    dup = router.route_to_user("alice", frame, {"bob":object()}, {"alice":"local"})
-    assert dup == ("error","DUPLICATE")
 
-    # turn on bypass; crafted payload with hops=0 should skip dedupe
-    os.environ["VULN_REPLAY"]="1"
-    frame2 = {"ts":1,"from":"sA","to":"sB","payload":{"hops":0}}
-    res2 = router.route_to_user("alice", frame2, {"bob":object()}, {"alice":"local"})
-    assert res2[0] in {"deliver_local","forward","error"}
-    os.environ["VULN_REPLAY"]="0"
+def _envelope(**kwargs):
+    data = {
+        "type": "USER_MESSAGE",
+        "from": "alice",
+        "to": "bob",
+        "ts": 1,
+        "payload": {"msg": "hi"},
+        "sig": "",
+    }
+    data.update(kwargs)
+    return proto.Envelope.model_validate(data)
+
+
+def test_route_local_user():
+    r = router.Router("srvA")
+    r.register_local_user("bob", object())
+    decision = r.route(_envelope())
+    assert decision.action == "deliver_local"
+    assert decision.target == "bob"
+
+
+def test_route_remote_forward():
+    r = router.Router("srvA")
+    r.register_server_link("srvB", object())
+    r.track_remote_users("srvB", ["charlie"])
+    decision = r.route(_envelope(to="charlie"))
+    assert decision.action == "forward"
+    assert decision.target == "srvB"
+
+
+def test_route_user_not_found():
+    r = router.Router("srvA")
+    decision = r.route(_envelope(to="nobody"))
+    assert decision.action == "error"
+    assert decision.code == "USER_NOT_FOUND"
+
+
+def test_dedupe_on_server_deliver():
+    r = router.Router("srvA")
+    r.register_local_user("bob", object())
+    env = _envelope(type="SERVER_DELIVER")
+    first = r.route(env)
+    assert first.action == "deliver_local"
+    second = r.route(env)
+    assert second.action == "drop"
+    assert second.code == "DUPLICATE"


### PR DESCRIPTION
## Summary
- add envelope validation helpers and transport ACK/ERROR builders
- implement router tables with duplicate suppression and websocket loops
- wire the server entrypoint to the router and extend unit coverage for validation/routing

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e338e463148320a8ce5aed84a53f00